### PR TITLE
Item history

### DIFF
--- a/src/Contracts/ItemHistoryWidget.php
+++ b/src/Contracts/ItemHistoryWidget.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Kontenta\Kontour\Contracts;
+
+interface ItemHistoryWidget extends AdminWidget
+{
+    /**
+     * Add an entry to an item's history
+     * @param AdminUser $user
+     * @param \DateTimeImmutable $datetime
+     * @param string $action
+     */
+    public function addEntry(AdminUser $user, \DateTimeImmutable $datetime, string $action = null ): ItemHistoryWidget;
+}

--- a/src/Contracts/ItemHistoryWidget.php
+++ b/src/Contracts/ItemHistoryWidget.php
@@ -10,5 +10,5 @@ interface ItemHistoryWidget extends AdminWidget
      * @param \DateTimeImmutable $datetime
      * @param string $action
      */
-    public function addEntry(AdminUser $user, \DateTimeImmutable $datetime, string $action = null ): ItemHistoryWidget;
+    public function addEntry(AdminUser $user, \DateTimeImmutable $datetime, string $action = null): ItemHistoryWidget;
 }

--- a/src/Contracts/ItemHistoryWidget.php
+++ b/src/Contracts/ItemHistoryWidget.php
@@ -6,9 +6,19 @@ interface ItemHistoryWidget extends AdminWidget
 {
     /**
      * Add an entry to an item's history
-     * @param AdminUser $user
-     * @param \DateTimeImmutable $datetime
-     * @param string $action
+     * @return $this
      */
-    public function addEntry(AdminUser $user, \DateTimeImmutable $datetime, string $action = null): ItemHistoryWidget;
+    public function addEntry(string $action, \DateTime $datetime, AdminUser $user = null): ItemHistoryWidget;
+    
+    /**
+     * Add a create entry to an item's history
+     * @return $this
+     */
+    public function addCreateEntry(\DateTime $datetime, AdminUser $user = null): ItemHistoryWidget;
+    
+    /**
+     * Add an update entry to an item's history
+     * @return $this
+     */
+    public function addUpdateEntry(\DateTime $datetime, AdminUser $user = null): ItemHistoryWidget;
 }


### PR DESCRIPTION
In the UML the function should be like this:

`addEdit(AdminUser $saved_by, DateTime $saved_at)`

But I thought that all actions performed on an item might not necessarily be a kind of edit. It could be  a create, publish, delete, update, view etc, so what about calling it something more general like "addEntry" ?

I also added the option to sepcify an action name.

Do you think this is a good idea, or should we stick to the UML?