### PR TITLE
Traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You need at least **Laravel 5.5** and **PHP 7.0** to use this package.
 In a service provider you can register your admin routes using convenient methods from the trait
 `Kontenta\Kontour\Concerns\RegistersAdminRoutes`.
 
+Adding links to the menu widget can be done using trait `Kontenta\Kontour\Concerns\RegistersMenuWidgetLinks`.
+
 ## Benefits in blade views (or controllers)
 
 In the Blade views you create for your admin pages you can inject a "view manager" instance:

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -2,13 +2,10 @@
 
 namespace Kontenta\Kontour\Concerns;
 
-use Kontenta\Kontour\Contracts\AuthorizesWithAbility as AuthorizesWithAbilityContract;
-use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\Guard;
+use Kontenta\Kontour\Contracts\AuthorizesWithAbility as AuthorizesWithAbilityContract;
 
-/**
- * Trait AuthorizesWithAbility
- */
 trait AuthorizesWithAbility
 {
     private $authorizesWithAbilityPolicyOrGate;
@@ -45,13 +42,13 @@ trait AuthorizesWithAbility
      * @param Authorizable $user
      * @return bool
      */
-    public function isAuthorized(Authorizable $user = null): bool 
+    public function isAuthorized(Authorizable $user = null): bool
     {
-        if($this->authorizesWithAbilityGuard) {
+        if ($this->authorizesWithAbilityGuard) {
             $user = $this->authorizesWithAbilityGuard->user();
         }
 
-        if(!$user) {
+        if (!$user) {
             return false;
         }
 

--- a/src/Concerns/RegistersAdminRoutes.php
+++ b/src/Concerns/RegistersAdminRoutes.php
@@ -15,8 +15,8 @@ trait RegistersAdminRoutes
      */
     public function registerAdminRoutes($routes)
     {
-        if (!$this->app->routesAreCached()) {
-            $this->app['router']->group($this->resolveAdminRouteManager()->getRouteAttributes(), $routes);
+        if (!app()->routesAreCached()) {
+            app('router')->group($this->resolveAdminRouteManager()->getRouteAttributes(), $routes);
         }
     }
 
@@ -27,13 +27,13 @@ trait RegistersAdminRoutes
      */
     public function registerAdminGuestRoutes($routes)
     {
-        if (!$this->app->routesAreCached()) {
-            $this->app['router']->group($this->resolveAdminRouteManager()->getGuestRouteAttributes(), $routes);
+        if (!app()->routesAreCached()) {
+            app('router')->group($this->resolveAdminRouteManager()->getGuestRouteAttributes(), $routes);
         }
     }
 
     protected function resolveAdminRouteManager(): \Kontenta\Kontour\Contracts\AdminRouteManager
     {
-        return $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
+        return app(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
     }
 }

--- a/src/Concerns/RegistersAdminRoutes.php
+++ b/src/Concerns/RegistersAdminRoutes.php
@@ -2,10 +2,6 @@
 
 namespace Kontenta\Kontour\Concerns;
 
-/**
- * Trait RegistersAdminRoutes
- * @property \Illuminate\Foundation\Application $app
- */
 trait RegistersAdminRoutes
 {
     /**

--- a/src/Concerns/RegistersAdminRoutes.php
+++ b/src/Concerns/RegistersAdminRoutes.php
@@ -5,7 +5,7 @@ namespace Kontenta\Kontour\Concerns;
 trait RegistersAdminRoutes
 {
     /**
-     * Register admin routes
+     * Register admin routes that require login
      * @param \Closure|string $routes
      * @see \Illuminate\Routing\Router::loadRoutes
      */
@@ -17,7 +17,7 @@ trait RegistersAdminRoutes
     }
 
     /**
-     * Register admin guest routes
+     * Register admin guest routes that don't require login
      * @param \Closure|string $routes
      * @see \Illuminate\Routing\Router::loadRoutes
      */

--- a/src/Concerns/RegistersAdminWidgets.php
+++ b/src/Concerns/RegistersAdminWidgets.php
@@ -4,10 +4,6 @@ namespace Kontenta\Kontour\Concerns;
 
 use Kontenta\Kontour\Contracts\AdminWidget;
 
-/**
- * Trait RegistersAdminWidgets
- * @property \Illuminate\Foundation\Application $app
- */
 trait RegistersAdminWidgets
 {
     /**

--- a/src/Concerns/RegistersMenuWidgetLinks.php
+++ b/src/Concerns/RegistersMenuWidgetLinks.php
@@ -2,12 +2,26 @@
 
 namespace Kontenta\Kontour\Concerns;
 
-use Kontenta\Kontour\Contracts\MenuWidget;
+use Kontenta\Kontour\AdminLink as UrlAdminLink;
 use Kontenta\Kontour\Contracts\AdminLink;
+use Kontenta\Kontour\Contracts\MenuWidget;
+use Kontenta\Kontour\RouteAdminLink;
 
 trait RegistersMenuWidgetLinks
 {
-    public function addMenuWidgetLink(AdminLink $link, string $desiredHeading = null)
+    public function addMenuWidgetUrl(string $url, string $name, string $description = null, string $desiredHeading = null)
+    {
+        $link = new UrlAdminLink($url, $name, $description);
+        $this->addMenuWidgetAdminLink($link, $desiredHeading);
+    }
+
+    public function addMenuWidgetRoute(string $routeName, string $name, string $description = null, string $desiredHeading = null)
+    {
+        $link = new RouteAdminLink($routeName, $name, $description);
+        $this->addMenuWidgetAdminLink($link, $desiredHeading);
+    }
+
+    public function addMenuWidgetAdminLink(AdminLink $link, string $desiredHeading = null)
     {
         $this->resolveMenuWidget()->addLink($link, $desiredHeading);
     }

--- a/src/Concerns/RegistersMenuWidgetLinks.php
+++ b/src/Concerns/RegistersMenuWidgetLinks.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kontenta\Kontour\Concerns;
+
+use Kontenta\Kontour\Contracts\MenuWidget;
+use Kontenta\Kontour\Contracts\AdminLink;
+
+trait RegistersMenuWidgetLinks
+{
+    public function addMenuWidgetLink(AdminLink $link, string $desiredHeading = null)
+    {
+        $this->resolveMenuWidget()->addLink($link, $desiredHeading);
+    }
+
+    protected function resolveMenuWidget(): MenuWidget
+    {
+        return app(MenuWidget::class);
+    }
+}

--- a/tests/Feature/Fakes/UserlandServiceProvider.php
+++ b/tests/Feature/Fakes/UserlandServiceProvider.php
@@ -2,17 +2,16 @@
 
 namespace Kontenta\Kontour\Tests\Feature\Fakes;
 
-use Kontenta\Kontour\RouteAdminLink;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Kontenta\Kontour\Concerns\RegistersAdminRoutes;
 use Kontenta\Kontour\Concerns\RegistersAdminWidgets;
+use Kontenta\Kontour\Concerns\RegistersMenuWidgetLinks;
 use Kontenta\Kontour\Contracts\PersonalRecentVisitsWidget;
 use Kontenta\Kontour\Contracts\TeamRecentVisitsWidget;
 
 class UserlandServiceProvider extends ServiceProvider
 {
-    use RegistersAdminRoutes, RegistersAdminWidgets;
+    use RegistersAdminRoutes, RegistersAdminWidgets, RegistersMenuWidgetLinks;
 
     /**
      * Register bindings in the container.
@@ -30,7 +29,7 @@ class UserlandServiceProvider extends ServiceProvider
         $this->registerRoutes();
         $this->registerResources();
         $this->registerWidgets();
-        $this->addMenuLink();
+        $this->registerMenuLinks();
     }
 
     protected function registerRoutes()
@@ -62,11 +61,10 @@ class UserlandServiceProvider extends ServiceProvider
         $this->registerAdminWidget($this->app->make(TeamRecentVisitsWidget::class));
     }
 
-    protected function addMenuLink()
+    protected function registerMenuLinks()
     {
         $routeName = 'userland.index';
         $name = 'Userland Tool';
-        $link = new RouteAdminLink($routeName, $name);
-        $this->app->make(\Kontenta\Kontour\Contracts\MenuWidget::class)->addLink($link);
+        $this->addMenuWidgetRoute($routeName, $name);
     }
 }


### PR DESCRIPTION
This PR adds trait `RegistersMenuWidgetLinks`, mainly for use in userland service providers.

...but it also cleans up the other traits a little (sorry):
- using Laravel's `app()` helper function
- removing obsolete docblocks
- code formatting
- sorting use statements alphabetically