### PR TITLE
Admin links rework

### DIFF
--- a/src/AdminLink.php
+++ b/src/AdminLink.php
@@ -18,7 +18,7 @@ class AdminLink implements AdminLinkContract, AuthorizesWithAbilityContract
     {
         $this->name = $name;
         $this->url = $url;
-        $this->description = $description;
+        $this->withDescription($description);
     }
 
     public function getUrl(): ?string
@@ -34,6 +34,18 @@ class AdminLink implements AdminLinkContract, AuthorizesWithAbilityContract
     public function getDescription(): ?string
     {
         return $this->description;
+    }
+
+    /**
+     * Set description fluently
+     * @param string $description
+     * @return $this
+     */
+    public function withDescription(string $description = null): AdminLinkContract
+    {
+        $this->description = $description;
+
+        return $this;
     }
 
     public function toHtml(): string

--- a/src/AdminLink.php
+++ b/src/AdminLink.php
@@ -10,14 +10,14 @@ class AdminLink implements AdminLinkContract, AuthorizesWithAbilityContract
 {
     use AuthorizesWithAbilityTrait;
 
-    protected $url;
     protected $name;
+    protected $url;
     protected $description;
 
-    public function __construct(string $url, string $name, string $description = null)
+    public function __construct(string $name, string $url, string $description = null)
     {
-        $this->url = $url;
         $this->name = $name;
+        $this->url = $url;
         $this->description = $description;
     }
 

--- a/src/AdminLink.php
+++ b/src/AdminLink.php
@@ -21,6 +21,11 @@ class AdminLink implements AdminLinkContract, AuthorizesWithAbilityContract
         $this->withDescription($description);
     }
 
+    public static function create(...$args): AdminLink
+    {
+        return new static(...$args);
+    }
+
     public function getUrl(): ?string
     {
         return $this->url;

--- a/src/Concerns/RegistersMenuWidgetLinks.php
+++ b/src/Concerns/RegistersMenuWidgetLinks.php
@@ -11,13 +11,13 @@ trait RegistersMenuWidgetLinks
 {
     public function addMenuWidgetUrl(string $url, string $name, string $description = null, string $desiredHeading = null)
     {
-        $link = new UrlAdminLink($url, $name, $description);
+        $link = new UrlAdminLink($name, $url, $description);
         $this->addMenuWidgetAdminLink($link, $desiredHeading);
     }
 
     public function addMenuWidgetRoute(string $routeName, string $name, string $description = null, string $desiredHeading = null)
     {
-        $link = new RouteAdminLink($routeName, $name, $description);
+        $link = new RouteAdminLink($name, $routeName, $description);
         $this->addMenuWidgetAdminLink($link, $desiredHeading);
     }
 

--- a/src/Concerns/RegistersMenuWidgetLinks.php
+++ b/src/Concerns/RegistersMenuWidgetLinks.php
@@ -2,28 +2,28 @@
 
 namespace Kontenta\Kontour\Concerns;
 
-use Kontenta\Kontour\AdminLink as UrlAdminLink;
-use Kontenta\Kontour\Contracts\AdminLink;
+use Kontenta\Kontour\AdminLink;
+use Kontenta\Kontour\Contracts\AdminLink as AdminLinkContract;
 use Kontenta\Kontour\Contracts\MenuWidget;
 use Kontenta\Kontour\RouteAdminLink;
 
 trait RegistersMenuWidgetLinks
 {
-    public function addMenuWidgetUrl(string $url, string $name, string $description = null, string $desiredHeading = null)
+    public function addMenuWidgetUrl(string $name, string $url, string $desiredHeading = null): AdminLink
     {
-        $link = new UrlAdminLink($name, $url, $description);
-        $this->addMenuWidgetAdminLink($link, $desiredHeading);
+        return $this->addMenuWidgetAdminLink(AdminLink::create($name, $url), $desiredHeading);
     }
 
-    public function addMenuWidgetRoute(string $routeName, string $name, string $description = null, string $desiredHeading = null)
+    public function addMenuWidgetRoute(string $name, string $routeName, $routeParameters = [], string $desiredHeading = null): RouteAdminLink
     {
-        $link = new RouteAdminLink($name, $routeName, $description);
-        $this->addMenuWidgetAdminLink($link, $desiredHeading);
+        return $this->addMenuWidgetAdminLink(RouteAdminLink::create($name, $routeName, $routeParameters), $desiredHeading);
     }
 
-    public function addMenuWidgetAdminLink(AdminLink $link, string $desiredHeading = null)
+    public function addMenuWidgetAdminLink(AdminLinkContract $link, string $desiredHeading = null): AdminLinkContract
     {
         $this->resolveMenuWidget()->addLink($link, $desiredHeading);
+
+        return $link;
     }
 
     protected function resolveMenuWidget(): MenuWidget

--- a/src/Contracts/AdminLink.php
+++ b/src/Contracts/AdminLink.php
@@ -11,4 +11,11 @@ interface AdminLink extends Authorizes, Htmlable
     public function getName(): string;
 
     public function getDescription(): ?string;
+
+    /**
+     * Set description fluently
+     * @param string $description
+     * @return $this
+     */
+    public function withDescription(string $description = null): AdminLink;
 }

--- a/src/RouteAdminLink.php
+++ b/src/RouteAdminLink.php
@@ -9,10 +9,10 @@ class RouteAdminLink extends AdminLink
 {
     protected $routeName;
 
-    public function __construct(string $routeName, string $name, string $description = null)
+    public function __construct(string $name, string $routeName, string $description = null)
     {
-        $this->routeName = $routeName;
         $this->name = $name;
+        $this->routeName = $routeName;
         $this->description = $description;
     }
 

--- a/src/RouteAdminLink.php
+++ b/src/RouteAdminLink.php
@@ -13,8 +13,20 @@ class RouteAdminLink extends AdminLink
     {
         $this->name = $name;
         $this->routeName = $routeName;
-        $this->routeParameters = $routeParameters;
+        $this->withRouteParameters($routeParameters);
         $this->withDescription($description);
+    }
+
+    /**
+     * Set route parameters fluently
+     * @param mixed $routeParameters
+     * @return $this
+     */
+    public function withRouteParameters($routeParameters = []): RouteAdminLink
+    {
+        $this->routeParameters = $routeParameters;
+
+        return $this;
     }
 
     public function getUrl(): ?string

--- a/src/RouteAdminLink.php
+++ b/src/RouteAdminLink.php
@@ -13,7 +13,7 @@ class RouteAdminLink extends AdminLink
     {
         $this->name = $name;
         $this->routeName = $routeName;
-        $this->description = $description;
+        $this->withDescription($description);
     }
 
     public function getUrl(): ?string

--- a/src/RouteAdminLink.php
+++ b/src/RouteAdminLink.php
@@ -2,22 +2,27 @@
 
 namespace Kontenta\Kontour;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 
 class RouteAdminLink extends AdminLink
 {
     protected $routeName;
+    protected $routeParameters;
 
-    public function __construct(string $name, string $routeName, string $description = null)
+    public function __construct(string $name, string $routeName, $routeParameters = [], string $description = null)
     {
         $this->name = $name;
         $this->routeName = $routeName;
+        $this->routeParameters = $routeParameters;
         $this->withDescription($description);
     }
 
     public function getUrl(): ?string
     {
-        return Route::has($this->routeName) ? URL::route($this->routeName) : null;
+        try {
+            return URL::route($this->routeName, $this->routeParameters);
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/tests/Feature/Fakes/UserlandController.php
+++ b/tests/Feature/Fakes/UserlandController.php
@@ -4,14 +4,14 @@ namespace Kontenta\Kontour\Tests\Feature\Fakes;
 
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Auth;
-use Kontenta\Kontour\Events\AdminToolVisited;
 use Kontenta\Kontour\AdminLink;
+use Kontenta\Kontour\Concerns\RegistersAdminWidgets;
+use Kontenta\Kontour\Contracts\CrumbtrailWidget;
+use Kontenta\Kontour\Contracts\ItemHistoryWidget;
+use Kontenta\Kontour\Contracts\MessageWidget;
+use Kontenta\Kontour\Events\AdminToolVisited;
 use Kontenta\Kontour\RouteAdminLink;
 use Kontenta\Kontour\ShowAdminVisit;
-use Kontenta\Kontour\Concerns\RegistersAdminWidgets;
-use Kontenta\Kontour\Contracts\ItemHistoryWidget;
-use Kontenta\Kontour\Contracts\CrumbtrailWidget;
-use Kontenta\Kontour\Contracts\MessageWidget;
 
 class UserlandController extends BaseController
 {
@@ -20,14 +20,13 @@ class UserlandController extends BaseController
     public function __construct(CrumbtrailWidget $crumbtrail)
     {
         $this->crumbtrail = $crumbtrail;
-        $link1 = new RouteAdminLink('userland.index', '1');
+        $link1 = new RouteAdminLink('1', 'userland.index');
         $this->crumbtrail->addLink($link1);
     }
 
-
     public function index()
     {
-        $link = new AdminLink(url()->full(), 'Recent Userland Tool');
+        $link = new AdminLink('Recent Userland Tool', url()->full());
         $user = Auth::guard(config('kontour.guard'))->user();
         $visit = new ShowAdminVisit($link, $user);
         event(new AdminToolVisited($visit));
@@ -56,7 +55,7 @@ class UserlandController extends BaseController
         $widget->addCreatedEntry(new \DateTime(), Auth::guard(config('kontour.guard'))->user());
         $widget->addUpdatedEntry(new \DateTime(), Auth::guard(config('kontour.guard'))->user());
 
-        $link2 = new AdminLink(url()->full(), '2');
+        $link2 = new AdminLink('2', url()->full());
         $this->crumbtrail->addLink($link2);
         $this->registerAdminWidget($this->crumbtrail, app(\Kontenta\Kontour\Contracts\AdminViewManager::class)->toolHeaderSection());
 

--- a/tests/Feature/Fakes/UserlandServiceProvider.php
+++ b/tests/Feature/Fakes/UserlandServiceProvider.php
@@ -63,8 +63,7 @@ class UserlandServiceProvider extends ServiceProvider
 
     protected function registerMenuLinks()
     {
-        $routeName = 'userland.index';
-        $name = 'Userland Tool';
-        $this->addMenuWidgetRoute($routeName, $name);
+        $this->addMenuWidgetRoute('Userland Tool', 'userland.index');
+        $this->addMenuWidgetUrl('External Link', 'http://external.com', 'External');
     }
 }

--- a/tests/Feature/RouteAdminLinkTest.php
+++ b/tests/Feature/RouteAdminLinkTest.php
@@ -9,7 +9,7 @@ class RouteAdminLinkTest extends IntegrationTest
 {
     public function test_url_is_null_when_route_does_not_exist()
     {
-        $link = new RouteAdminLink('not.existing', 'Hej', '"Hejsanhejsan"');
+        $link = new RouteAdminLink('Hej', 'not.existing', '"Hejsanhejsan"');
 
         $this->assertNull($link->getUrl());
         $this->assertEquals('<a title="&quot;Hejsanhejsan&quot;">Hej</a>', $link->toHtml());

--- a/tests/Feature/RouteAdminLinkTest.php
+++ b/tests/Feature/RouteAdminLinkTest.php
@@ -7,11 +7,39 @@ use Kontenta\Kontour\Tests\IntegrationTest;
 
 class RouteAdminLinkTest extends IntegrationTest
 {
+    /**
+     * Configure the environment.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        // Test with Laravel's default password reset config
+        // This is to have the route kontour.password.reset requiring parameter token available
+        $app['config']->set('kontour.passwords', 'users');
+        parent::getEnvironmentSetUp($app);
+    }
+
     public function test_url_is_null_when_route_does_not_exist()
     {
-        $link = new RouteAdminLink('Hej', 'not.existing', '"Hejsanhejsan"');
+        $link = new RouteAdminLink('Gone', 'not.existing');
 
         $this->assertNull($link->getUrl());
-        $this->assertEquals('<a title="&quot;Hejsanhejsan&quot;">Hej</a>', $link->toHtml());
+        $this->assertEquals('<a >Gone</a>', $link->toHtml());
+    }
+
+    public function test_url_is_null_when_parameters_missing()
+    {
+        $link = new RouteAdminLink('Reset password', 'kontour.password.reset');
+
+        $this->assertNull($link->getUrl());
+    }
+
+    public function test_route_parameters_can_be_added_in_constructor()
+    {
+        $link = new RouteAdminLink('Reset password', 'kontour.password.reset', ["token" => 'abc']);
+
+        $this->assertEquals(route('kontour.password.reset', ["token" => 'abc']), $link->getUrl());
     }
 }

--- a/tests/Feature/RouteAdminLinkTest.php
+++ b/tests/Feature/RouteAdminLinkTest.php
@@ -50,4 +50,12 @@ class RouteAdminLinkTest extends IntegrationTest
 
         $this->assertEquals(route('kontour.password.reset', ["token" => 'abc']), $link->getUrl());
     }
+
+    public function test_can_be_created_statically()
+    {
+        $link = RouteAdminLink::create('Reset password', 'kontour.password.reset', ["token" => 'abc']);
+
+        $this->assertTrue($link instanceof RouteAdminLink);
+        $this->assertEquals(route('kontour.password.reset', ["token" => 'abc']), $link->getUrl());
+    }
 }

--- a/tests/Feature/RouteAdminLinkTest.php
+++ b/tests/Feature/RouteAdminLinkTest.php
@@ -42,4 +42,12 @@ class RouteAdminLinkTest extends IntegrationTest
 
         $this->assertEquals(route('kontour.password.reset', ["token" => 'abc']), $link->getUrl());
     }
+
+    public function test_route_parameters_can_be_added_fluently()
+    {
+        $link = new RouteAdminLink('Reset password', 'kontour.password.reset');
+        $link = $link->withRouteParameters(["token" => 'abc']);
+
+        $this->assertEquals(route('kontour.password.reset', ["token" => 'abc']), $link->getUrl());
+    }
 }

--- a/tests/Feature/UserlandControllerTest.php
+++ b/tests/Feature/UserlandControllerTest.php
@@ -49,6 +49,8 @@ class UserlandControllerTest extends UserlandAdminToolTest
         $response->assertSee('<ul data-kontour-widget="menu">');
         $response->assertSee('>main<');
         $response->assertSee('<a href="' . route('userland.index') . '">Userland Tool</a>');
+        $response->assertSee('>External<');
+        $response->assertSee('<a href="http://external.com">External Link</a>');
     }
 
     public function test_recent_visits_widgets()

--- a/tests/Feature/UserlandControllerTest.php
+++ b/tests/Feature/UserlandControllerTest.php
@@ -4,11 +4,11 @@ namespace Kontenta\Kontour\Tests\Feature;
 
 use Illuminate\Support\Facades\Event;
 use Kontenta\Kontour\AdminLink;
-use Kontenta\Kontour\Tests\Feature\Fakes\User;
-use Kontenta\Kontour\Tests\UserlandAdminToolTest;
 use Kontenta\Kontour\EditAdminVisit;
 use Kontenta\Kontour\Events\AdminToolVisited;
 use Kontenta\Kontour\ShowAdminVisit;
+use Kontenta\Kontour\Tests\Feature\Fakes\User;
+use Kontenta\Kontour\Tests\UserlandAdminToolTest;
 
 class UserlandControllerTest extends UserlandAdminToolTest
 {
@@ -54,14 +54,14 @@ class UserlandControllerTest extends UserlandAdminToolTest
     public function test_recent_visits_widgets()
     {
         $otherUser = factory(User::class)->create();
-        $link = new AdminLink(route('userland.edit', 1), 'Recent Userland Tool');
+        $link = new AdminLink('Recent Userland Tool', route('userland.edit', 1));
         $visit = new EditAdminVisit($link, $this->user);
         event(new AdminToolVisited($visit));
         event(new AdminToolVisited($visit));
-        $link = new AdminLink(route('userland.index'), 'Other Recent Userland Tool');
+        $link = new AdminLink('Other Recent Userland Tool', route('userland.index'));
         $visit = new ShowAdminVisit($link, $otherUser);
         event(new AdminToolVisited($visit));
-        $link = new AdminLink(route('userland.edit', 1), 'Other Recent Userland Tool');
+        $link = new AdminLink('Other Recent Userland Tool', route('userland.edit', 1));
         $visit = new EditAdminVisit($link, $otherUser);
         event(new AdminToolVisited($visit));
         event(new AdminToolVisited($visit));
@@ -102,8 +102,8 @@ class UserlandControllerTest extends UserlandAdminToolTest
     {
         $response = $this->actingAs($this->user)->get(route('userland.edit', 1));
         $response->assertSee('<nav aria-label="Crumb trail" data-kontour-widget="crumbtrail">');
-        $response->assertSee('<a href="'.route('userland.index').'">1</a>');
-        $response->assertSee('<li aria-current="page"><a href="'.route('userland.edit', 1).'">2</a>');
+        $response->assertSee('<a href="' . route('userland.index') . '">1</a>');
+        $response->assertSee('<li aria-current="page"><a href="' . route('userland.edit', 1) . '">2</a>');
     }
 
     public function test_message_widget()

--- a/tests/Unit/AdminLinkTest.php
+++ b/tests/Unit/AdminLinkTest.php
@@ -2,14 +2,14 @@
 
 namespace Kontenta\Kontour\Tests\Unit;
 
-use Kontenta\Kontour\Tests\UnitTest;
 use Kontenta\Kontour\AdminLink;
+use Kontenta\Kontour\Tests\UnitTest;
 
 class AdminLinkTest extends UnitTest
 {
     public function test_can_be_converted_to_html()
     {
-        $link = new AdminLink('http://hej.com', 'Hej', '"Hejsanhejsan"');
+        $link = new AdminLink('Hej', 'http://hej.com', '"Hejsanhejsan"');
 
         $this->assertEquals('<a href="http://hej.com" title="&quot;Hejsanhejsan&quot;">Hej</a>', $link->toHtml());
     }

--- a/tests/Unit/AdminLinkTest.php
+++ b/tests/Unit/AdminLinkTest.php
@@ -13,4 +13,12 @@ class AdminLinkTest extends UnitTest
 
         $this->assertEquals('<a href="http://hej.com" title="&quot;Hejsanhejsan&quot;">Hej</a>', $link->toHtml());
     }
+
+    public function test_description_can_be_added_fluently()
+    {
+        $link = new AdminLink('Hej', 'http://hej.com');
+        $link = $link->withDescription('Hejsanhejsan');
+
+        $this->assertEquals('<a href="http://hej.com" title="Hejsanhejsan">Hej</a>', $link->toHtml());
+    }
 }

--- a/tests/Unit/AdminLinkTest.php
+++ b/tests/Unit/AdminLinkTest.php
@@ -21,4 +21,14 @@ class AdminLinkTest extends UnitTest
 
         $this->assertEquals('<a href="http://hej.com" title="Hejsanhejsan">Hej</a>', $link->toHtml());
     }
+
+    public function test_can_be_created_statically()
+    {
+        $link = AdminLink::create('Hej', 'http://hej.com', 'Hejsanhejsan');
+
+        $this->assertTrue($link instanceof AdminLink);
+        $this->assertEquals('Hej', $link->getName());
+        $this->assertEquals('http://hej.com', $link->getUrl());
+        $this->assertEquals('Hejsanhejsan', $link->getDescription());
+    }
 }


### PR DESCRIPTION
This PR contains substantial changes related to `AdminLink` and its implementations.

The main reason for the rework is because `RouteAdminLink` needs to handle [route parameters for named routes](https://laravel.com/docs/5.7/urls#urls-for-named-routes).

But it also does this to get there:

1. It switches argument orders for many methods. The idea is to keep the arguments that are common across methods/implementation first, then required arguments, and of course last optional arguments.
The big thing here is that `$name` is now provided first to `AdminLink` constructors, followed by any params required to generate the actual url.

2. It adds fluent methods `withDescription()` and `withRouteParameters()` so that parameters that were optional in the constructor can be added later, regardless of order.

3. Adds static `create()` methods on all `AdminLink`s, just passing along the arguments to the constructor. This makes chaining calls easier.

4. Adds tests for plain url links and also "sections" in the menu widget. So we're sure `$desiredSectionName` is being handled correctly.