### PR TITLE
Serialization of AuthorizesWithAbility

### DIFF
--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -5,6 +5,7 @@ namespace Kontenta\Kontour\Concerns;
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Auth;
 use Kontenta\Kontour\Contracts\AuthorizesWithAbility as AuthorizesWithAbilityContract;
 
 trait AuthorizesWithAbility
@@ -31,10 +32,10 @@ trait AuthorizesWithAbility
 
     /**
      * Register a guard to be used for the authorization
-     * @param Guard $guard
+     * @param string $guard
      * @return $this
      */
-    public function registerGuardForAuthorization(Guard $guard): AuthorizesWithAbilityContract
+    public function registerGuardForAuthorization(string $guard): AuthorizesWithAbilityContract
     {
         $this->authorizesWithAbilityGuard = $guard;
 
@@ -48,8 +49,13 @@ trait AuthorizesWithAbility
      */
     public function isAuthorized(Authorizable $user = null): bool
     {
-        if ($this->authorizesWithAbilityGuard) {
-            $user = $this->authorizesWithAbilityGuard->user();
+        try {
+            if ($this->authorizesWithAbilityGuard) {
+                $user = Auth::guard($this->authorizesWithAbilityGuard)->user();
+            }
+        } catch (\Exception $e) {
+            // Something is wrong with the guard... perhaps it no longer exists?
+            return false;
         }
 
         if (!$user) {

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -12,19 +12,19 @@ trait AuthorizesWithAbility
 {
     use SerializesModels; //If $authorizesWithAbilityArguments is just a single Eloquent model, this will serialize it. (But not if it's an array unfortunately)
 
-    private $authorizesWithAbilityPolicyOrGate;
+    private $authorizesWithAbilityName;
     private $authorizesWithAbilityArguments;
     private $authorizesWithAbilityGuard;
 
-    /**
+     /**
      * Register a policy or gate to be used for the authorization
-     * @param string $policyOrGate
-     * @param $arguments
+     * @param string $ability name from a Gate/Policy
+     * @param array|mixed $arguments for the ability check, typically a model instance
      * @return $this
      */
-    public function registerAbilityForAuthorization(string $policyOrGate, $arguments = []): AuthorizesWithAbilityContract
+    public function registerAbilityForAuthorization(string $ability, $arguments = []): AuthorizesWithAbilityContract
     {
-        $this->authorizesWithAbilityPolicyOrGate = $policyOrGate;
+        $this->authorizesWithAbilityName = $ability;
         $this->authorizesWithAbilityArguments = $arguments;
 
         return $this;
@@ -62,6 +62,6 @@ trait AuthorizesWithAbility
             return false;
         }
 
-        return $user->can($this->authorizesWithAbilityPolicyOrGate, $this->authorizesWithAbilityArguments);
+        return $user->can($this->authorizesWithAbilityName, $this->authorizesWithAbilityArguments);
     }
 }

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -62,6 +62,6 @@ trait AuthorizesWithAbility
             return false;
         }
 
-        return $user->can($this->authorizesWithAbilityPolicyOrGate, ...$this->authorizesWithAbilityArguments);
+        return $user->can($this->authorizesWithAbilityPolicyOrGate, $this->authorizesWithAbilityArguments);
     }
 }

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -58,7 +58,7 @@ trait AuthorizesWithAbility
             return false;
         }
 
-        if (!$user) {
+        if (!$user instanceof Authorizable) {
             return false;
         }
 

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -34,6 +34,7 @@ trait AuthorizesWithAbility
     public function registerGuardForAuthorization(Guard $guard): AuthorizesWithAbilityContract
     {
         $this->authorizesWithAbilityGuard = $guard;
+
         return $this;
     }
 

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -4,10 +4,13 @@ namespace Kontenta\Kontour\Concerns;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Queue\SerializesModels;
 use Kontenta\Kontour\Contracts\AuthorizesWithAbility as AuthorizesWithAbilityContract;
 
 trait AuthorizesWithAbility
 {
+    use SerializesModels; //If $authorizesWithAbilityArguments is just a single Eloquent model, this will serialize it. (But not if it's an array unfortunately)
+
     private $authorizesWithAbilityPolicyOrGate;
     private $authorizesWithAbilityArguments;
     private $authorizesWithAbilityGuard;

--- a/src/Contracts/AuthorizesWithAbility.php
+++ b/src/Contracts/AuthorizesWithAbility.php
@@ -8,11 +8,11 @@ interface AuthorizesWithAbility extends Authorizes
 {
     /**
      * Register a policy or gate to be used for the authorization
-     * @param string $policyOrGate
-     * @param $arguments
+     * @param string $ability name from a Gate/Policy
+     * @param array|mixed $arguments for the ability check, typically a model instance
      * @return $this
      */
-    public function registerAbilityForAuthorization(string $policyOrGate, $arguments = []): AuthorizesWithAbility;
+    public function registerAbilityForAuthorization(string $ability, $arguments = []): AuthorizesWithAbility;
 
     /**
      * Register a guard to be used for the authorization

--- a/src/Contracts/AuthorizesWithAbility.php
+++ b/src/Contracts/AuthorizesWithAbility.php
@@ -16,8 +16,8 @@ interface AuthorizesWithAbility extends Authorizes
 
     /**
      * Register a guard to be used for the authorization
-     * @param Guard $guard
+     * @param string $guard
      * @return $this
      */
-    public function registerGuardForAuthorization(Guard $guard): AuthorizesWithAbility;
+    public function registerGuardForAuthorization(string $guard): AuthorizesWithAbility;
 }

--- a/tests/Feature/AuthorizesWithAbilityTest.php
+++ b/tests/Feature/AuthorizesWithAbilityTest.php
@@ -19,13 +19,14 @@ class AuthorizesWithAbilityTest extends IntegrationTest
         parent::setUp();
         $this->prepareDatabase();
         $this->user = factory(User::class)->create();
+
+        Gate::define('testGate', function ($user) {
+            return true;
+        });
     }
 
     public function test_authorizing_with_gate()
     {
-        Gate::define('testGate', function ($user) {
-            return true;
-        });
         $link = AdminLink::create('Reset password', 'http://test.com')->registerAbilityForAuthorization('testGate');
 
         $this->assertTrue($link->isAuthorized($this->user));

--- a/tests/Feature/AuthorizesWithAbilityTest.php
+++ b/tests/Feature/AuthorizesWithAbilityTest.php
@@ -20,32 +20,46 @@ class AuthorizesWithAbilityTest extends IntegrationTest
         $this->prepareDatabase();
         $this->user = factory(User::class)->create();
 
-        Gate::define('testGate', function ($user) {
-            return true;
+        Gate::define('testGate', function ($user, $argument) {
+            return $user->id == $argument->id;
         });
     }
 
     public function test_authorizing_with_gate()
     {
-        $link = AdminLink::create('Reset password', 'http://test.com')->registerAbilityForAuthorization('testGate');
+        $link = AdminLink::create('Reset password', 'http://test.com');
+        $link->registerAbilityForAuthorization('testGate', $this->user);
 
         $this->assertTrue($link->isAuthorized($this->user));
     }
 
     public function test_not_authorized_without_user()
     {
-        $link = AdminLink::create('Reset password', 'http://test.com')->registerAbilityForAuthorization('testGate');
+        $link = AdminLink::create('Reset password', 'http://test.com');
+        $link->registerAbilityForAuthorization('testGate', $this->user);
 
         $this->assertFalse($link->isAuthorized());
+    }
+
+    public function test_not_authorized_with_non_existing_guard()
+    {
+        $link = AdminLink::create('Reset password', 'http://test.com');
+        $link->registerAbilityForAuthorization('testGate', $this->user);
+        $link->registerGuardForAuthorization('non.existing.guard');
+
+        $this->assertFalse($link->isAuthorized($this->user));
     }
 
     public function test_can_be_serialized_and_deserialized()
     {
         $link = AdminLink::create('Reset password', 'http://test.com');
+        $link->registerAbilityForAuthorization('testGate', $this->user);
 
         $serializedLink = serialize($link);
+        $link->__wakeup(); // Restore any serialized models on the original object
         $unserializedLink = unserialize($serializedLink);
 
+        $this->assertTrue($unserializedLink->isAuthorized($this->user));
         $this->assertEquals($link, $unserializedLink, "Unserialization did not produce the orginal object structure");
     }
 }

--- a/tests/Feature/AuthorizesWithAbilityTest.php
+++ b/tests/Feature/AuthorizesWithAbilityTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kontenta\Kontour\Tests\Feature;
+
+use Kontenta\Kontour\AdminLink;
+use Kontenta\Kontour\Tests\IntegrationTest;
+use Kontenta\Kontour\Tests\Feature\Fakes\User;
+
+class AuthorizesWithAbilityTest extends IntegrationTest
+{
+    /**
+     * @var User
+     */
+    private $user;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->prepareDatabase();
+        $this->user = factory(User::class)->create();
+    }
+
+    public function test_can_be_serialized_and_deserialized() {
+        $link = AdminLink::create('Reset password', 'http://test.com');
+
+        $serializedLink = serialize($link);
+        $unserializedLink = unserialize($serializedLink);
+
+        $this->assertEquals($link, $unserializedLink, "Unserialization did not produce the orginal object structure");
+    }
+}

--- a/tests/Feature/AuthorizesWithAbilityTest.php
+++ b/tests/Feature/AuthorizesWithAbilityTest.php
@@ -2,9 +2,10 @@
 
 namespace Kontenta\Kontour\Tests\Feature;
 
+use Illuminate\Support\Facades\Gate;
 use Kontenta\Kontour\AdminLink;
-use Kontenta\Kontour\Tests\IntegrationTest;
 use Kontenta\Kontour\Tests\Feature\Fakes\User;
+use Kontenta\Kontour\Tests\IntegrationTest;
 
 class AuthorizesWithAbilityTest extends IntegrationTest
 {
@@ -20,7 +21,25 @@ class AuthorizesWithAbilityTest extends IntegrationTest
         $this->user = factory(User::class)->create();
     }
 
-    public function test_can_be_serialized_and_deserialized() {
+    public function test_authorizing_with_gate()
+    {
+        Gate::define('testGate', function ($user) {
+            return true;
+        });
+        $link = AdminLink::create('Reset password', 'http://test.com')->registerAbilityForAuthorization('testGate');
+
+        $this->assertTrue($link->isAuthorized($this->user));
+    }
+
+    public function test_not_authorized_without_user()
+    {
+        $link = AdminLink::create('Reset password', 'http://test.com')->registerAbilityForAuthorization('testGate');
+
+        $this->assertFalse($link->isAuthorized());
+    }
+
+    public function test_can_be_serialized_and_deserialized()
+    {
         $link = AdminLink::create('Reset password', 'http://test.com');
 
         $serializedLink = serialize($link);


### PR DESCRIPTION
This PR makes the `AuthorizesWithAbility` implementations serializable by registering any Guard using a guard name as a string instead of an object.

Also, `SerializesModels` is used if a single argument is given with the gate or policy name. Unfortunately the model serialization does not work if multiple arguments are to be given to the "ability", but that's a pretty rare case. Most cases just have a single model to check, so we'll have to leave it that way for now. The problem is that `SerializesModels` only serializes models if they're in a declared property of the class, not if they're in an array or other structure deeper in the object.