### PR TITLE
Use PHP CodeSniffer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 .editorconfig export-ignore
 .travis.yml
 phpunit.xml.dist export-ignore
+phpcs.xml.dist export-ignore
 DEVELOPMENT.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ tags
 .DS_Store
 /build
 phpunit.xml
+phpcs.xml
 /tests/Browser/console/
 /tests/Browser/screenshots/

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ before_script:
   - ./vendor/laravel/dusk/bin/chromedriver-linux &
 
 script:
+  - vendor/bin/phpcs
   - vendor/bin/phpunit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,4 +26,7 @@ copy the file `phpunit.xml.dist` to `phpunit.xml` and modify the latter to your 
 
 ## Following PSR2
 
-This project can be checked against configured coding standars using `composer phpcs` from the project directory.
+This project can be checked against configured coding standards using `composer phpcs` from the project directory.
+
+Automatic attempt to fix some reported coding standard violations can be run with
+`./vendor/bin/phpcbf` from the project directory.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,3 +23,7 @@
 
 If you want your own local configuration for phpunit,
 copy the file `phpunit.xml.dist` to `phpunit.xml` and modify the latter to your needs.
+
+## Following PSR2
+
+This project can be checked against configured coding standars using `composer phpcs` from the project directory.

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "sort-packages": true
   },
   "scripts": {
-    "test": "vendor/bin/phpunit"
+    "test": "vendor/bin/phpunit",
+    "phpcs": "vendor/bin/phpcs"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "mockery/mockery": "^1.2",
     "orchestra/testbench": "^3.5",
     "orchestra/testbench-dusk": "^3.5.5|3.6.x-dev",
-    "phpunit/phpunit": ">6.5"
+    "phpunit/phpunit": ">6.5",
+    "squizlabs/php_codesniffer": "^3.3"
   },
   "autoload": {
     "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="PSR2">
+<description>The PSR2 coding standard.</description>
+<rule ref="PSR2"/>
+<file>src/</file>
+<exclude-pattern>vendor</exclude-pattern>
+<exclude-pattern>resources</exclude-pattern>
+<exclude-pattern>database/</exclude-pattern>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,8 @@
 <ruleset name="PSR2">
 <description>The PSR2 coding standard.</description>
 <rule ref="PSR2"/>
-<file>src/</file>
+<file>src</file>
 <exclude-pattern>vendor</exclude-pattern>
 <exclude-pattern>resources</exclude-pattern>
-<exclude-pattern>database/</exclude-pattern>
+<exclude-pattern>database</exclude-pattern>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,4 @@
 <description>The PSR2 coding standard.</description>
 <rule ref="PSR2"/>
 <file>src</file>
-<exclude-pattern>vendor</exclude-pattern>
-<exclude-pattern>resources</exclude-pattern>
-<exclude-pattern>database</exclude-pattern>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,5 +2,8 @@
 <ruleset name="PSR2">
 <description>The PSR2 coding standard.</description>
 <rule ref="PSR2"/>
+<file>config</file>
+<file>database</file>
+<file>routes</file>
 <file>src</file>
 </ruleset>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 
 Route::namespace('Kontenta\Kontour\Http\Controllers')->group(function () {
-    if(!Route::has('kontour.index')) {
+    if (!Route::has('kontour.index')) {
         Route::get('/', 'IndexController')->name('kontour.index');
     }
 });

--- a/src/AdminWidgetManager.php
+++ b/src/AdminWidgetManager.php
@@ -34,12 +34,11 @@ class AdminWidgetManager implements WidgetManagerContract
 
     public function addWidget(AdminWidget $widget, string $desiredSectionName = null): WidgetManagerContract
     {
-        if(empty($desiredSectionName))
-        {
+        if (empty($desiredSectionName)) {
             $desiredSectionName = $this->viewManager->widgetSection();
         }
 
-        if(!$this->widgets->has($desiredSectionName)) {
+        if (!$this->widgets->has($desiredSectionName)) {
             $this->widgets->put($desiredSectionName, new Collection());
         }
 
@@ -55,7 +54,7 @@ class AdminWidgetManager implements WidgetManagerContract
 
     public function getWidgetsForSection(string $sectionName): Collection
     {
-        return $this->widgets->get($sectionName, new Collection())->filter(function(AdminWidget $widget) {
+        return $this->widgets->get($sectionName, new Collection())->filter(function (AdminWidget $widget) {
             return $widget->isAuthorized($this->guard->user());
         });
     }

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -10,7 +10,10 @@ use Kontenta\Kontour\Contracts\AuthorizesWithAbility as AuthorizesWithAbilityCon
 
 trait AuthorizesWithAbility
 {
-    use SerializesModels; //If $authorizesWithAbilityArguments is just a single Eloquent model, this will serialize it. (But not if it's an array unfortunately)
+    // If $authorizesWithAbilityArguments is just a single Eloquent model,
+    // the SerializesModels trait will serialize it,
+    // but not if more than one argument is passsed in an array unfortunately.
+    use SerializesModels;
 
     private $authorizesWithAbilityName;
     private $authorizesWithAbilityArguments;

--- a/src/Concerns/RegistersMenuWidgetLinks.php
+++ b/src/Concerns/RegistersMenuWidgetLinks.php
@@ -14,9 +14,16 @@ trait RegistersMenuWidgetLinks
         return $this->addMenuWidgetAdminLink(AdminLink::create($name, $url), $desiredHeading);
     }
 
-    public function addMenuWidgetRoute(string $name, string $routeName, $routeParameters = [], string $desiredHeading = null): RouteAdminLink
-    {
-        return $this->addMenuWidgetAdminLink(RouteAdminLink::create($name, $routeName, $routeParameters), $desiredHeading);
+    public function addMenuWidgetRoute(
+        string $name,
+        string $routeName,
+        $routeParameters = [],
+        string $desiredHeading = null
+    ): RouteAdminLink {
+        return $this->addMenuWidgetAdminLink(
+            RouteAdminLink::create($name, $routeName, $routeParameters),
+            $desiredHeading
+        );
     }
 
     public function addMenuWidgetAdminLink(AdminLinkContract $link, string $desiredHeading = null): AdminLinkContract

--- a/src/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/src/Http/Controllers/Auth/ForgotPasswordController.php
@@ -42,6 +42,4 @@ class ForgotPasswordController extends Controller
     {
         return Password::broker(config('kontour.passwords', null));
     }
-
-
 }

--- a/src/Providers/KontourServiceProvider.php
+++ b/src/Providers/KontourServiceProvider.php
@@ -8,18 +8,18 @@ use Illuminate\Support\ServiceProvider;
 use Kontenta\Kontour\AdminRouteManager;
 use Kontenta\Kontour\AdminViewManager;
 use Kontenta\Kontour\AdminWidgetManager;
+use Kontenta\Kontour\Concerns\RegistersAdminRoutes;
+use Kontenta\Kontour\Concerns\RegistersAdminWidgets;
 use Kontenta\Kontour\Http\Middleware\AuthenticateAdmin;
 use Kontenta\Kontour\Http\Middleware\RedirectIfAuthenticated;
 use Kontenta\Kontour\RecentVisitsRepository;
-use Kontenta\Kontour\Widgets\ItemHistoryWidget;
 use Kontenta\Kontour\Widgets\CrumbtrailWidget;
-use Kontenta\Kontour\Widgets\MessageWidget;
+use Kontenta\Kontour\Widgets\ItemHistoryWidget;
 use Kontenta\Kontour\Widgets\MenuWidget;
+use Kontenta\Kontour\Widgets\MessageWidget;
 use Kontenta\Kontour\Widgets\PersonalRecentVisitsWidget;
 use Kontenta\Kontour\Widgets\TeamRecentVisitsWidget;
 use Kontenta\Kontour\Widgets\UserAccountWidget;
-use Kontenta\Kontour\Concerns\RegistersAdminRoutes;
-use Kontenta\Kontour\Concerns\RegistersAdminWidgets;
 
 class KontourServiceProvider extends ServiceProvider
 {
@@ -173,8 +173,14 @@ class KontourServiceProvider extends ServiceProvider
 
     protected function registerWidgets()
     {
-        $this->registerAdminWidget($this->app->make(\Kontenta\Kontour\Contracts\MenuWidget::class), $this->app->make(\Kontenta\Kontour\Contracts\AdminViewManager::class)->navSection());
-        $this->registerAdminWidget($this->app->make(\Kontenta\Kontour\Contracts\UserAccountWidget::class), $this->app->make(\Kontenta\Kontour\Contracts\AdminViewManager::class)->headerSection());
+        $this->registerAdminWidget(
+            $this->app->make(\Kontenta\Kontour\Contracts\MenuWidget::class),
+            $this->app->make(\Kontenta\Kontour\Contracts\AdminViewManager::class)->navSection()
+        );
+        $this->registerAdminWidget(
+            $this->app->make(\Kontenta\Kontour\Contracts\UserAccountWidget::class),
+            $this->app->make(\Kontenta\Kontour\Contracts\AdminViewManager::class)->headerSection()
+        );
     }
 
     /**

--- a/src/RecentVisitsRepository.php
+++ b/src/RecentVisitsRepository.php
@@ -35,7 +35,8 @@ class RecentVisitsRepository implements RecentVisitsRepositoryContract
         Cache::forever($key, $visits);
     }
 
-    protected function generateCacheKey($type) {
+    protected function generateCacheKey($type)
+    {
         return 'kontour-recent-visits-'.$type;
     }
 }

--- a/src/Widgets/MenuWidget.php
+++ b/src/Widgets/MenuWidget.php
@@ -27,12 +27,11 @@ class MenuWidget implements MenuWidgetContract
 
     public function addLink(AdminLink $link, string $desiredHeading = null): MenuWidgetContract
     {
-        if(empty($desiredHeading))
-        {
+        if (empty($desiredHeading)) {
             $desiredHeading = 'main';
         }
 
-        if(!$this->links->has($desiredHeading)) {
+        if (!$this->links->has($desiredHeading)) {
             $this->links->put($desiredHeading, new Collection());
         }
 


### PR DESCRIPTION
This PR adds a a configuration and dev-dependency for PHP CodeSniffer enforcing the PSR2 coding standard + run before phpunit by Travis CI.

Usage documentation is included in `DEVELOPMENT.md`.

This PR also includes fixes for those few PSR2 deviations that were found in the code base, so that the build passes.