### PR TITLE
Pass authorization by default if no ability has been set

### DIFF
--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -15,11 +15,16 @@ trait AuthorizesWithAbility
     // but not if more than one argument is passsed in an array unfortunately.
     use SerializesModels;
 
+    /**
+     * @var bool Set to false to fail authorization if no ability has been registered
+     */
+    protected $authorizesWithoutAbility = true;
+
     private $authorizesWithAbilityName;
     private $authorizesWithAbilityArguments;
     private $authorizesWithAbilityGuard;
 
-     /**
+    /**
      * Register a policy or gate to be used for the authorization
      * @param string $ability name from a Gate/Policy
      * @param array|mixed $arguments for the ability check, typically a model instance
@@ -52,6 +57,10 @@ trait AuthorizesWithAbility
      */
     public function isAuthorized(Authorizable $user = null): bool
     {
+        if (!$this->authorizesWithAbilityName) {
+            return $this->authorizesWithoutAbility;
+        }
+
         try {
             if ($this->authorizesWithAbilityGuard) {
                 $user = Auth::guard($this->authorizesWithAbilityGuard)->user();

--- a/tests/Feature/AuthorizesWithAbilityTest.php
+++ b/tests/Feature/AuthorizesWithAbilityTest.php
@@ -33,6 +33,13 @@ class AuthorizesWithAbilityTest extends IntegrationTest
         $this->assertTrue($link->isAuthorized($this->user));
     }
 
+    public function test_authorized_without_ability()
+    {
+        $link = AdminLink::create('Reset password', 'http://test.com');
+
+        $this->assertTrue($link->isAuthorized());
+    }
+
     public function test_not_authorized_without_user()
     {
         $link = AdminLink::create('Reset password', 'http://test.com');


### PR DESCRIPTION
Before, if no ability had been set on an `AuthorizesWithAbility` object (like an `AdminLink`) the outcome of the authorization would be a fail.

With this PR the default behaviour is to pass auth unless an ability name has been set, so that links created by default will be shown to all admin users.