### PR TITLE
Turn off xdebug unless needed for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 before_script:
+  - if [[ $COVERAGE == "" ]]; then phpenv config-rm xdebug.ini; fi
   - composer config discard-changes true
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Disabling xdebug makes Travis CI finish tests a little faster.

Tips no 1 from https://www.tomasvotruba.cz/blog/2018/10/29/7-tips-to-get-the-most-out-of-travis-ci/