### PR TITLE
Blank passwords

### DIFF
--- a/resources/views/forms/input.blade.php
+++ b/resources/views/forms/input.blade.php
@@ -1,8 +1,10 @@
 <div>
   @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
   <div>
-    <input type="{{ $type ?? 'text' }}"
-      value="{{ old($name, $value ?? $slot ?? $model[$name] ?? '') }}"
+    <input type="{{ $type = $type ?? 'text' }}"
+      @if($type != 'password')
+        value="{{ old($name, $value ?? $slot ?? $model[$name] ?? '') }}"
+      @endif
       @include('kontour::forms.partials.inputAttributes', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
     >
     @include('kontour::forms.partials.errors', ['errorsId' => $errorsId])

--- a/src/Auth/AdminUser.php
+++ b/src/Auth/AdminUser.php
@@ -16,7 +16,7 @@ class AdminUser extends \Illuminate\Foundation\Auth\User implements AdminUserCon
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'name', 'email'
     ];
 
     /**
@@ -28,7 +28,7 @@ class AdminUser extends \Illuminate\Foundation\Auth\User implements AdminUserCon
         'password', 'remember_token',
     ];
 
-    public function getDisplayName() : string
+    public function getDisplayName(): string
     {
         return $this->getEmailForPasswordReset();
     }


### PR DESCRIPTION
This PR makes password fields not refill their values by default.

It also stops password fields in admin users from being "fillable".