### PR TITLE
Display authorized links only

### DIFF
--- a/src/Concerns/DispatchesAdminToolEvents.php
+++ b/src/Concerns/DispatchesAdminToolEvents.php
@@ -6,14 +6,17 @@ use Kontenta\Kontour\AdminLink;
 use Kontenta\Kontour\EditAdminVisit;
 use Kontenta\Kontour\Events\AdminToolVisited;
 use Kontenta\Kontour\ShowAdminVisit;
+use Kontenta\Kontour\Concerns\ResolvesAdminUser;
 
 trait DispatchesAdminToolEvents
 {
+    use ResolvesAdminUser;
+
     public function dispatchShowAdminToolVisitedEvent(string $name, string $description = null)
     {
         $visit = new ShowAdminVisit(
             $this->createCurrentAdminLink($name, $description),
-            $this->getCurrentAdminUser()
+            $this->user()
         );
         event(new AdminToolVisited($visit));
     }
@@ -22,7 +25,7 @@ trait DispatchesAdminToolEvents
     {
         $visit = new EditAdminVisit(
             $this->createCurrentAdminLink($name, $description),
-            $this->getCurrentAdminUser()
+            $this->user()
         );
         event(new AdminToolVisited($visit));
     }
@@ -30,10 +33,5 @@ trait DispatchesAdminToolEvents
     public function createCurrentAdminLink(string $name, string $description = null)
     {
         return AdminLink::create($name, url()->full(), $description);
-    }
-
-    public function getCurrentAdminUser()
-    {
-        return auth()->guard(config('kontour.guard'))->user();
     }
 }

--- a/src/Concerns/DispatchesAdminToolEvents.php
+++ b/src/Concerns/DispatchesAdminToolEvents.php
@@ -16,7 +16,7 @@ trait DispatchesAdminToolEvents
     {
         $visit = new ShowAdminVisit(
             $this->createCurrentAdminLink($name, $description),
-            $this->user()
+            $this->adminUser()
         );
         event(new AdminToolVisited($visit));
     }
@@ -25,7 +25,7 @@ trait DispatchesAdminToolEvents
     {
         $visit = new EditAdminVisit(
             $this->createCurrentAdminLink($name, $description),
-            $this->user()
+            $this->adminUser()
         );
         event(new AdminToolVisited($visit));
     }

--- a/src/Concerns/ResolvesAdminUser.php
+++ b/src/Concerns/ResolvesAdminUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kontenta\Kontour\Concerns;
+
+use Illuminate\Support\Facades\Auth;
+use Kontenta\Kontour\Contracts\AdminUser;
+
+trait ResolvesAdminUser
+{
+    /**
+     * Get the currently logged in admin user
+     * @return Kontenta\Kontour\Contracts\AdminUser
+     */
+    public function user()
+    {
+        return Auth::guard(config('kontour.guard'))->user();
+    }
+}

--- a/src/Concerns/ResolvesAdminUser.php
+++ b/src/Concerns/ResolvesAdminUser.php
@@ -11,7 +11,7 @@ trait ResolvesAdminUser
      * Get the currently logged in admin user
      * @return Kontenta\Kontour\Contracts\AdminUser
      */
-    public function user()
+    public function user(): ?AdminUser
     {
         return Auth::guard(config('kontour.guard'))->user();
     }

--- a/src/Concerns/ResolvesAdminUser.php
+++ b/src/Concerns/ResolvesAdminUser.php
@@ -11,7 +11,7 @@ trait ResolvesAdminUser
      * Get the currently logged in admin user
      * @return Kontenta\Kontour\Contracts\AdminUser
      */
-    public function user(): ?AdminUser
+    public function adminUser(): ?AdminUser
     {
         return Auth::guard(config('kontour.guard'))->user();
     }

--- a/src/Widgets/CrumbtrailWidget.php
+++ b/src/Widgets/CrumbtrailWidget.php
@@ -44,6 +44,6 @@ class CrumbtrailWidget implements CrumbtrailWidgetContract
 
     protected function authorizedLinks()
     {
-        return $this->links->filter->isAuthorized($this->user());
+        return $this->links->filter->isAuthorized($this->adminUser());
     }
 }

--- a/src/Widgets/CrumbtrailWidget.php
+++ b/src/Widgets/CrumbtrailWidget.php
@@ -4,9 +4,10 @@ namespace Kontenta\Kontour\Widgets;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Support\Collection;
-use Kontenta\Kontour\Contracts\CrumbtrailWidget as CrumbtrailWidgetContract;
-use Kontenta\Kontour\Contracts\AdminLink;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
+use Kontenta\Kontour\Contracts\AdminLink;
+use Kontenta\Kontour\Contracts\CrumbtrailWidget as CrumbtrailWidgetContract;
 
 class CrumbtrailWidget implements CrumbtrailWidgetContract
 {
@@ -23,7 +24,7 @@ class CrumbtrailWidget implements CrumbtrailWidgetContract
     public function toHtml()
     {
         if ($this->links->count() > 1) {
-            return View::make('kontour::widgets.crumbtrail', ['links' => $this->links])->render();
+            return View::make('kontour::widgets.crumbtrail', ['links' => $this->authorizedLinks()])->render();
         }
     }
 
@@ -37,5 +38,10 @@ class CrumbtrailWidget implements CrumbtrailWidgetContract
     public function isAuthorized(Authorizable $user = null): bool
     {
         return true;
+    }
+
+    protected function authorizedLinks()
+    {
+        return $this->links->filter->isAuthorized(Auth::guard(config('kontour.guard'))->user());
     }
 }

--- a/src/Widgets/CrumbtrailWidget.php
+++ b/src/Widgets/CrumbtrailWidget.php
@@ -4,13 +4,15 @@ namespace Kontenta\Kontour\Widgets;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
+use Kontenta\Kontour\Concerns\ResolvesAdminUser;
 use Kontenta\Kontour\Contracts\AdminLink;
 use Kontenta\Kontour\Contracts\CrumbtrailWidget as CrumbtrailWidgetContract;
 
 class CrumbtrailWidget implements CrumbtrailWidgetContract
 {
+    use ResolvesAdminUser;
+
     /**
      * @var Collection
      */
@@ -42,6 +44,6 @@ class CrumbtrailWidget implements CrumbtrailWidgetContract
 
     protected function authorizedLinks()
     {
-        return $this->links->filter->isAuthorized(Auth::guard(config('kontour.guard'))->user());
+        return $this->links->filter->isAuthorized($this->user());
     }
 }

--- a/src/Widgets/MenuWidget.php
+++ b/src/Widgets/MenuWidget.php
@@ -4,12 +4,15 @@ namespace Kontenta\Kontour\Widgets;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Support\Collection;
-use Kontenta\Kontour\Contracts\MenuWidget as MenuWidgetContract;
-use Kontenta\Kontour\Contracts\AdminLink;
 use Illuminate\Support\Facades\View;
+use Kontenta\Kontour\Concerns\ResolvesAdminUser;
+use Kontenta\Kontour\Contracts\AdminLink;
+use Kontenta\Kontour\Contracts\MenuWidget as MenuWidgetContract;
 
 class MenuWidget implements MenuWidgetContract
 {
+    use ResolvesAdminUser;
+
     /**
      * @var Collection
      */
@@ -22,7 +25,7 @@ class MenuWidget implements MenuWidgetContract
 
     public function toHtml()
     {
-        return View::make('kontour::widgets.menu', ['links' => $this->links])->render();
+        return View::make('kontour::widgets.menu', ['links' => $this->authorizedLinks()])->render();
     }
 
     public function addLink(AdminLink $link, string $desiredHeading = null): MenuWidgetContract
@@ -48,5 +51,12 @@ class MenuWidget implements MenuWidgetContract
     public function isAuthorized(Authorizable $user = null): bool
     {
         return (bool) $user;
+    }
+
+    protected function authorizedLinks()
+    {
+        return $this->links->map(function ($links) {
+            return $links->filter->isAuthorized($this->adminUser());
+        });
     }
 }

--- a/src/Widgets/PersonalRecentVisitsWidget.php
+++ b/src/Widgets/PersonalRecentVisitsWidget.php
@@ -3,13 +3,15 @@
 namespace Kontenta\Kontour\Widgets;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
-use Kontenta\Kontour\RecentVisitsRepository;
+use Kontenta\Kontour\Concerns\ResolvesAdminUser;
 use Kontenta\Kontour\Contracts\PersonalRecentVisitsWidget as PersonalRecentVisitsWidgetContract;
+use Kontenta\Kontour\RecentVisitsRepository;
 
 class PersonalRecentVisitsWidget implements PersonalRecentVisitsWidgetContract
 {
+    use ResolvesAdminUser;
+
     protected $repository;
 
     public function __construct(RecentVisitsRepository $repository)
@@ -30,7 +32,7 @@ class PersonalRecentVisitsWidget implements PersonalRecentVisitsWidgetContract
     private function getVisits()
     {
         return $this->repository->getShowVisits()->merge($this->repository->getEditVisits())->filter(function ($visit) {
-            return $visit->getUser()->is(Auth::guard(config('kontour.guard'))->user());
+            return $visit->getUser()->is($this->user()) and $visit->getLink()->isAuthorized($this->user());
         })->unique(function ($visit) {
             return $visit->getLink()->getUrl();
         })->sortByDesc(function ($visit) {

--- a/src/Widgets/PersonalRecentVisitsWidget.php
+++ b/src/Widgets/PersonalRecentVisitsWidget.php
@@ -32,7 +32,7 @@ class PersonalRecentVisitsWidget implements PersonalRecentVisitsWidgetContract
     private function getVisits()
     {
         return $this->repository->getShowVisits()->merge($this->repository->getEditVisits())->filter(function ($visit) {
-            return $visit->getUser()->is($this->user()) and $visit->getLink()->isAuthorized($this->user());
+            return $visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
         })->unique(function ($visit) {
             return $visit->getLink()->getUrl();
         })->sortByDesc(function ($visit) {

--- a/src/Widgets/TeamRecentVisitsWidget.php
+++ b/src/Widgets/TeamRecentVisitsWidget.php
@@ -33,7 +33,7 @@ class TeamRecentVisitsWidget implements TeamRecentVisitsWidgetContract
     private function getVisits()
     {
         return $this->repository->getEditVisits()->filter(function ($visit) {
-            return !$visit->getUser()->is($this->user()) and $visit->getLink()->isAuthorized($this->user());
+            return !$visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
         })->unique(function ($visit) {
             return $visit->getLink()->getUrl();
         })->sortByDesc(function ($visit) {

--- a/src/Widgets/TeamRecentVisitsWidget.php
+++ b/src/Widgets/TeamRecentVisitsWidget.php
@@ -5,11 +5,14 @@ namespace Kontenta\Kontour\Widgets;
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
+use Kontenta\Kontour\Concerns\ResolvesAdminUser;
 use Kontenta\Kontour\RecentVisitsRepository;
 use Kontenta\Kontour\Contracts\TeamRecentVisitsWidget as TeamRecentVisitsWidgetContract;
 
 class TeamRecentVisitsWidget implements TeamRecentVisitsWidgetContract
 {
+    use ResolvesAdminUser;
+
     protected $repository;
 
     public function __construct(RecentVisitsRepository $repository)
@@ -30,7 +33,7 @@ class TeamRecentVisitsWidget implements TeamRecentVisitsWidgetContract
     private function getVisits()
     {
         return $this->repository->getEditVisits()->filter(function ($visit) {
-            return !$visit->getUser()->is(Auth::guard(config('kontour.guard'))->user());
+            return !$visit->getUser()->is($this->user()) and $visit->getLink()->isAuthorized($this->user());
         })->unique(function ($visit) {
             return $visit->getLink()->getUrl();
         })->sortByDesc(function ($visit) {

--- a/src/Widgets/UserAccountWidget.php
+++ b/src/Widgets/UserAccountWidget.php
@@ -3,10 +3,9 @@
 namespace Kontenta\Kontour\Widgets;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
-use Kontenta\Kontour\Contracts\UserAccountWidget as UserAccountWidgetContract;
 use Kontenta\Kontour\Concerns\ResolvesAdminUser;
+use Kontenta\Kontour\Contracts\UserAccountWidget as UserAccountWidgetContract;
 
 class UserAccountWidget implements UserAccountWidgetContract
 {

--- a/src/Widgets/UserAccountWidget.php
+++ b/src/Widgets/UserAccountWidget.php
@@ -6,13 +6,15 @@ use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
 use Kontenta\Kontour\Contracts\UserAccountWidget as UserAccountWidgetContract;
+use Kontenta\Kontour\Concerns\ResolvesAdminUser;
 
 class UserAccountWidget implements UserAccountWidgetContract
 {
+    use ResolvesAdminUser;
+
     public function toHtml()
     {
-        $user = Auth::guard(config('kontour.guard'))->user();
-        return View::make('kontour::widgets.userAccount', compact('user'))->render();
+        return View::make('kontour::widgets.userAccount', ['user' => $this->user()])->render();
     }
 
     public function isAuthorized(Authorizable $user = null): bool

--- a/src/Widgets/UserAccountWidget.php
+++ b/src/Widgets/UserAccountWidget.php
@@ -13,7 +13,7 @@ class UserAccountWidget implements UserAccountWidgetContract
 
     public function toHtml()
     {
-        return View::make('kontour::widgets.userAccount', ['user' => $this->user()])->render();
+        return View::make('kontour::widgets.userAccount', ['user' => $this->adminUser()])->render();
     }
 
     public function isAuthorized(Authorizable $user = null): bool

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -69,7 +69,7 @@ class AuthenticationTest extends IntegrationTest
          * @var $routeManager \Kontenta\Kontour\Contracts\AdminRouteManager
          */
         $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
-        $response = $this->actingAs($this->user)->get($routeManager->indexUrl());
+        $response = $this->actingAs($this->user, 'admin')->get($routeManager->indexUrl());
 
         $response->assertSuccessful();
     }
@@ -77,7 +77,7 @@ class AuthenticationTest extends IntegrationTest
     public function test_admin_user_account_widget()
     {
         $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
-        $response = $this->actingAs($this->user)->get($routeManager->indexUrl());
+        $response = $this->actingAs($this->user, 'admin')->get($routeManager->indexUrl());
         $response->assertSee('<section data-kontour-widget="userAccount">');
         $response->assertSee($this->user->getDisplayName());
         $response->assertSee('<button type="submit">Logout</button>');
@@ -86,8 +86,7 @@ class AuthenticationTest extends IntegrationTest
     public function test_user_account_widget()
     {
         $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
-        $user = new \Illuminate\Foundation\Auth\User();
-        $response = $this->actingAs($user)->get($routeManager->indexUrl());
+        $response = $this->actingAs($this->user, 'admin')->get($routeManager->indexUrl());
         $response->assertSee('<section data-kontour-widget="userAccount">');
         $response->assertSee('<button type="submit">Logout</button>');
     }
@@ -98,7 +97,7 @@ class AuthenticationTest extends IntegrationTest
          * @var $routeManager \Kontenta\Kontour\Contracts\AdminRouteManager
          */
         $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
-        $response = $this->actingAs($this->user)->post($routeManager->logoutUrl());
+        $response = $this->actingAs($this->user, 'admin')->post($routeManager->logoutUrl());
 
         $response->assertRedirect($routeManager->loginUrl());
         $this->assertGuest();
@@ -109,7 +108,7 @@ class AuthenticationTest extends IntegrationTest
          * @var $routeManager \Kontenta\Kontour\Contracts\AdminRouteManager
          */
         $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
-        $response = $this->actingAs($this->user)->get($routeManager->loginUrl());
+        $response = $this->actingAs($this->user, 'admin')->get($routeManager->loginUrl());
 
         $response->assertRedirect($routeManager->indexUrl());
 

--- a/tests/Feature/Fakes/UserlandController.php
+++ b/tests/Feature/Fakes/UserlandController.php
@@ -3,7 +3,6 @@
 namespace Kontenta\Kontour\Tests\Feature\Fakes;
 
 use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Support\Facades\Auth;
 use Kontenta\Kontour\AdminLink;
 use Kontenta\Kontour\Concerns\DispatchesAdminToolEvents;
 use Kontenta\Kontour\Concerns\RegistersAdminWidgets;
@@ -14,7 +13,8 @@ use Kontenta\Kontour\Contracts\MessageWidget;
 
 class UserlandController extends BaseController
 {
-    use RegistersAdminWidgets, DispatchesAdminToolEvents;
+    use RegistersAdminWidgets;
+    use DispatchesAdminToolEvents;
 
     private $viewManager;
 
@@ -54,8 +54,8 @@ class UserlandController extends BaseController
     public function edit($id)
     {
         $widget = $this->findOrRegisterAdminWidget(ItemHistoryWidget::class);
-        $widget->addCreatedEntry(new \DateTime(), Auth::guard(config('kontour.guard'))->user());
-        $widget->addUpdatedEntry(new \DateTime(), Auth::guard(config('kontour.guard'))->user());
+        $widget->addCreatedEntry(new \DateTime(), $this->adminUser());
+        $widget->addUpdatedEntry(new \DateTime(), $this->adminUser());
 
         $link2 = AdminLink::create('2', url()->full());
         $this->crumbtrail->addLink($link2);

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -66,8 +66,8 @@ class PasswordResetTest extends IntegrationTest
         $response->assertRedirect($routeManager->indexUrl());
         $response->assertSessionHas('status');
         $response->assertSessionMissing('errors');
-        $this->assertCredentials(['email' => $this->user->getEmailForPasswordReset(), 'password' => $new_password]);
-        $this->assertAuthenticatedAs($this->user);
+        $this->assertCredentials(['email' => $this->user->getEmailForPasswordReset(), 'password' => $new_password], 'admin');
+        $this->assertAuthenticatedAs($this->user, 'admin');
     }
 
 }

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -2,10 +2,10 @@
 
 namespace Kontenta\Kontour\Tests\Feature;
 
-use Kontenta\Kontour\Auth\Notifications\ResetPassword;
-use Kontenta\Kontour\Tests\IntegrationTest;
-use Kontenta\Kontour\Tests\Feature\Fakes\User;
 use Illuminate\Support\Facades\Notification;
+use Kontenta\Kontour\Auth\Notifications\ResetPassword;
+use Kontenta\Kontour\Tests\Feature\Fakes\User;
+use Kontenta\Kontour\Tests\IntegrationTest;
 
 class PasswordResetTest extends IntegrationTest
 {

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -21,19 +21,6 @@ class PasswordResetTest extends IntegrationTest
         $this->user = factory(User::class)->create();
     }
 
-    /**
-     * Configure the environment.
-     *
-     * @param  \Illuminate\Foundation\Application $app
-     * @return void
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-        // Test with Laravel's default password reset config
-        $app['config']->set('kontour.passwords', 'users');
-        parent::getEnvironmentSetUp($app);
-    }
-
     public function test_request_password_reset_url()
     {
         $response = $this->get(route('kontour.password.request'));

--- a/tests/Feature/UserlandControllerTest.php
+++ b/tests/Feature/UserlandControllerTest.php
@@ -28,7 +28,7 @@ class UserlandControllerTest extends UserlandAdminToolTest
     {
         Event::fake();
 
-        $response = $this->actingAs($this->user)->get(route('userland.index'));
+        $response = $this->actingAs($this->user, 'admin')->get(route('userland.index'));
 
         $response->assertSee('<main');
         $response->assertSee('UserlandAdminWidget');
@@ -44,7 +44,7 @@ class UserlandControllerTest extends UserlandAdminToolTest
 
     public function test_menu_widget()
     {
-        $response = $this->actingAs($this->user)->get(route('userland.index'));
+        $response = $this->actingAs($this->user, 'admin')->get(route('userland.index'));
 
         $response->assertSee('<ul data-kontour-widget="menu">');
         $response->assertSee('>main<');
@@ -68,7 +68,7 @@ class UserlandControllerTest extends UserlandAdminToolTest
         event(new AdminToolVisited($visit));
         event(new AdminToolVisited($visit));
 
-        $response = $this->actingAs($this->user)->get(route('userland.index'));
+        $response = $this->actingAs($this->user, 'admin')->get(route('userland.index'));
 
         $response->assertSuccessful();
 
@@ -94,7 +94,7 @@ class UserlandControllerTest extends UserlandAdminToolTest
 
     public function test_item_history_widget()
     {
-        $response = $this->actingAs($this->user)->get(route('userland.edit', 1));
+        $response = $this->actingAs($this->user, 'admin')->get(route('userland.edit', 1));
         $response->assertSee('<section data-kontour-widget="itemHistory">');
         $response->assertSee('<header>Item History</header>');
         $response->assertSee('<li lang="en" data-kontour-entry-action="created" data-kontour-username="' . $this->user->getDisplayName() . '">');
@@ -103,7 +103,7 @@ class UserlandControllerTest extends UserlandAdminToolTest
 
     public function test_crumbtrail_widget()
     {
-        $response = $this->actingAs($this->user)->get(route('userland.edit', 1));
+        $response = $this->actingAs($this->user, 'admin')->get(route('userland.edit', 1));
         $response->assertSee('<nav aria-label="Crumb trail" data-kontour-widget="crumbtrail">');
         $response->assertSee('<a href="' . route('userland.index') . '">1</a>');
         $response->assertSee('<li aria-current="page"><a href="' . route('userland.edit', 1) . '">2</a>');
@@ -111,14 +111,14 @@ class UserlandControllerTest extends UserlandAdminToolTest
 
     public function test_message_widget()
     {
-        $response = $this->actingAs($this->user)->get(route('userland.edit', 1));
+        $response = $this->actingAs($this->user, 'admin')->get(route('userland.edit', 1));
         $response->assertSee('<section data-kontour-widget="message">');
         $response->assertSee('<li data-kontour-message-level="info">Hello World!</li>');
     }
 
     public function test_css_and_js_additions()
     {
-        $response = $this->actingAs($this->user)->get(route('userland.index'));
+        $response = $this->actingAs($this->user, 'admin')->get(route('userland.index'));
         $response->assertSee('<link href="'.url('admin.css').'" rel="stylesheet" type="text/css">');
         $response->assertSee('<link href="'.url('userland.css').'" rel="stylesheet" type="text/css">');
         $response->assertSee('<link href="'.url('userland-index.css').'" rel="stylesheet" type="text/css">');

--- a/tests/IntegrationTestSetupTrait.php
+++ b/tests/IntegrationTestSetupTrait.php
@@ -32,6 +32,23 @@ trait IntegrationTestSetupTrait
         // Setup default database to use sqlite :memory:
         $app['config']->set('database.default', 'testing');
         $app['config']->set('auth.providers.users.model', User::class);
+
+        // Configure admin user provider
+        $app['config']->set('auth.guards.admin', [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ]);
+        $app['config']->set('auth.providers.admins', [
+            'driver' => 'eloquent',
+            'model' => User::class,
+        ]);
+        $app['config']->set('auth.passwords.admins', [
+            'provider' => 'admins',
+            'table' => 'password_resets',
+            'expire' => 60,
+        ]);
+        $app['config']->set('kontour.guard', 'admin');
+        $app['config']->set('kontour.passwords', 'admins');
     }
 
     /**
@@ -80,6 +97,6 @@ trait IntegrationTestSetupTrait
      */
     protected function getBasePath()
     {
-        return __DIR__.'/../vendor/orchestra/testbench-dusk/laravel';
+        return __DIR__ . '/../vendor/orchestra/testbench-dusk/laravel';
     }
 }


### PR DESCRIPTION
This PR makes sure the current user can access admin links (in widgets etc) before printing them.

To arrive at that I created a trait `ResolvesAdminUsers` that has a method `adminUser()`.
This trait is now used everywhere where the current user is needed.

The tests had to be updated to use a specific admin guard, not the default Laravel web guard, and when doing that I added a specific password reset too.