### PR TITLE
Require user to implement AdminUser contract

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ language: php
 matrix:
   include:
     - php: 7.1
-      env: LARAVEL='5.6.*'
-    - php: 7.1
       env: LARAVEL='5.7.*'
-    - php: 7.2
-      env: LARAVEL='5.6.*'
     - php: 7.2
       env: LARAVEL='5.7.*'
   fast_finish: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,7 +21,7 @@ copy the file `phpunit.xml.dist` to `phpunit.xml` and modify the latter to your 
 ### Testing with different versions
 
 [Travis CI](https://travis-ci.org/kontenta/kontour) is set up to run tests
-against PHP 7.1 and 7.2 in combination with Laravel 5.6 and 5.7.
+against PHP 7.1 and 7.2 in combination with Laravel 5.7.
 See `.travis.yml` for details.
 
 - `composer update --prefer-lowest` can be used before running tests for testing backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Kontour is an admin page manager for Laravel.
 It provides a shared "frame" for the admin routes you create in your Laravel apps, or in packages you write.
 
-You need at least **Laravel 5.5** and **PHP 7.0** to use this package.
+You need at least **Laravel 5.7** and **PHP 7.1** to use this package.
 
 ## Benefits in service providers
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "laravel/dusk": ">3.0.1",
     "mockery/mockery": "^1.2",
     "orchestra/testbench": "^3.7",
-    "orchestra/testbench-dusk": "^3.5.5|3.7.x-dev",
+    "orchestra/testbench-dusk": "^3.5.6|3.7.x-dev",
     "squizlabs/php_codesniffer": "^3.3"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "laravel/framework": "5.7.*"
   },
   "require-dev": {
-    "laravel/dusk": "^3.0.2",
+    "laravel/dusk": ">3.0.1",
     "mockery/mockery": "^1.2",
     "orchestra/testbench": "^3.7",
     "orchestra/testbench-dusk": "^3.5.5|3.7.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "mockery/mockery": "^1.2",
     "orchestra/testbench": "^3.7",
     "orchestra/testbench-dusk": "^3.5.6|3.7.x-dev",
-    "squizlabs/php_codesniffer": "^3.3"
+    "squizlabs/php_codesniffer": "^3.3",
+    "timacdonald/log-fake": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "laravel/framework": "~5.5"
   },
   "require-dev": {
-    "laravel/dusk": ">2.0.13",
+    "laravel/dusk": "^3.0.2",
     "mockery/mockery": "^1.2",
     "orchestra/testbench": "^3.5",
     "orchestra/testbench-dusk": "^3.5.5|3.6.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,13 @@
   "license": "MIT",
   "require": {
     "php": ">=7.1.0",
-    "laravel/framework": "~5.5"
+    "laravel/framework": "5.7.*"
   },
   "require-dev": {
     "laravel/dusk": "^3.0.2",
     "mockery/mockery": "^1.2",
-    "orchestra/testbench": "^3.5",
-    "orchestra/testbench-dusk": "^3.5.5|3.6.x-dev",
-    "phpunit/phpunit": ">6.5",
+    "orchestra/testbench": "^3.7",
+    "orchestra/testbench-dusk": "^3.5.5|3.7.x-dev",
     "squizlabs/php_codesniffer": "^3.3"
   },
   "autoload": {

--- a/src/Http/Middleware/AuthenticateAdmin.php
+++ b/src/Http/Middleware/AuthenticateAdmin.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Kontenta\Kontour\Contracts\AdminAuthenticateMiddleware;
 use Kontenta\Kontour\Contracts\AdminRouteManager;
+use Kontenta\Kontour\Contracts\AdminUser;
 
 class AuthenticateAdmin extends \Illuminate\Auth\Middleware\Authenticate implements AdminAuthenticateMiddleware
 {
@@ -24,8 +25,13 @@ class AuthenticateAdmin extends \Illuminate\Auth\Middleware\Authenticate impleme
         $guards[] = config('kontour.guard');
         $this->authenticate($request, $guards);
 
-        if (!$this->auth->user() instanceof \Kontenta\Kontour\Contracts\AdminUser) {
-            throw new \UnexpectedValueException('Admin user class needs to implement \Kontenta\Kontour\Contracts\AdminUser');
+        if (!$this->auth->user() instanceof AdminUser) {
+            throw new \UnexpectedValueException(implode(' ', [
+                get_class($this->auth->user()),
+                'needs to implement',
+                AdminUser::class,
+                'to be used as a Kontour admin user',
+            ]));
         }
 
         return $next($request);

--- a/src/Http/Middleware/AuthenticateAdmin.php
+++ b/src/Http/Middleware/AuthenticateAdmin.php
@@ -24,6 +24,10 @@ class AuthenticateAdmin extends \Illuminate\Auth\Middleware\Authenticate impleme
         $guards[] = config('kontour.guard');
         $this->authenticate($request, $guards);
 
+        if (!$this->auth->user() instanceof \Kontenta\Kontour\Contracts\AdminUser) {
+            throw new \UnexpectedValueException('Admin user class needs to implement \Kontenta\Kontour\Contracts\AdminUser');
+        }
+
         return $next($request);
     }
 

--- a/src/Http/Middleware/AuthenticateAdmin.php
+++ b/src/Http/Middleware/AuthenticateAdmin.php
@@ -31,6 +31,8 @@ class AuthenticateAdmin extends \Illuminate\Auth\Middleware\Authenticate impleme
                 'needs to implement',
                 AdminUser::class,
                 'to be used as a Kontour admin user',
+                'with guard',
+                "'" . config('auth.defaults.guard') . "'",
             ]));
         }
 

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -64,6 +64,14 @@ class AuthenticationTest extends IntegrationTest
         $response->assertRedirect($routeManager->indexUrl());
     }
 
+    public function test_non_admin_user_cant_be_logged_in() {
+        $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
+        $user = new \Illuminate\Foundation\Auth\User();
+        $response = $this->actingAs($user, 'admin')->get($routeManager->indexUrl());
+
+        $response->assertStatus(500);
+    }
+
     public function test_index_route() {
         /**
          * @var $routeManager \Kontenta\Kontour\Contracts\AdminRouteManager

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -2,8 +2,10 @@
 
 namespace Kontenta\Kontour\Tests\Feature;
 
-use Kontenta\Kontour\Tests\IntegrationTest;
+use Illuminate\Support\Facades\Log;
 use Kontenta\Kontour\Tests\Feature\Fakes\User;
+use Kontenta\Kontour\Tests\IntegrationTest;
+use TiMacDonald\Log\LogFake;
 
 class AuthenticationTest extends IntegrationTest
 {
@@ -64,15 +66,25 @@ class AuthenticationTest extends IntegrationTest
         $response->assertRedirect($routeManager->indexUrl());
     }
 
-    public function test_non_admin_user_cant_be_logged_in() {
+    public function test_non_admin_user_cant_be_logged_in()
+    {
+        Log::swap(new LogFake);
         $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
         $user = new \Illuminate\Foundation\Auth\User();
         $response = $this->actingAs($user, 'admin')->get($routeManager->indexUrl());
 
         $response->assertStatus(500);
+        Log::assertLogged('error', function ($message, $context) {
+            return (
+                str_contains($message, 'Kontenta\Kontour\Contracts\AdminUser') and
+                str_contains($message, 'Illuminate\Foundation\Auth\User') and
+                str_contains($message, "'admin'")
+            );
+        });
     }
 
-    public function test_index_route() {
+    public function test_index_route()
+    {
         /**
          * @var $routeManager \Kontenta\Kontour\Contracts\AdminRouteManager
          */
@@ -111,7 +123,8 @@ class AuthenticationTest extends IntegrationTest
         $this->assertGuest();
     }
 
-    public function test_already_logged_in_user_is_redirected_from_login_url() {
+    public function test_already_logged_in_user_is_redirected_from_login_url()
+    {
         /**
          * @var $routeManager \Kontenta\Kontour\Contracts\AdminRouteManager
          */


### PR DESCRIPTION
This PR makes the auth checking middleware throw an exception if the user is not an implementation of the kontour admin user contract.

To arrive at that we are dropping support for Laravel 5.6, to use features of Laravel's auth middleware in 5.7.

And to test the exception we pull in `timacdonald/log-fake` that can... fake the logger 😄 