### PR TITLE
Fix recent widgets

### DIFF
--- a/config/kontour.php
+++ b/config/kontour.php
@@ -100,4 +100,19 @@ return [
         \Kontenta\Kontour\Contracts\PersonalRecentVisitsWidget::class => 'kontourWidgets',
         \Kontenta\Kontour\Contracts\TeamRecentVisitsWidget::class => 'kontourWidgets',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Recent visits
+    |--------------------------------------------------------------------------
+    |
+    | Number of links to show in recent visits widgets.
+    |
+     */
+
+    'max_recent_visits' => [
+        'personal' => 7,
+        'team' => 9,
+    ],
+
 ];

--- a/src/RecentVisitsRepository.php
+++ b/src/RecentVisitsRepository.php
@@ -43,7 +43,8 @@ class RecentVisitsRepository implements RecentVisitsRepositoryContract
         $userId = $event->visit->getUser()->getAuthIdentifier();
         $this->addRecentUser($userId);
         $key = $this->generateCacheKey($event->visit->getType(), $userId);
-        Cache::forever($key,
+        Cache::forever(
+            $key,
             Cache::get($key, new Collection())
                 ->prepend($event->visit)
                 ->unique(function ($visit) {

--- a/src/RecentVisitsRepository.php
+++ b/src/RecentVisitsRepository.php
@@ -43,10 +43,14 @@ class RecentVisitsRepository implements RecentVisitsRepositoryContract
         $userId = $event->visit->getUser()->getAuthIdentifier();
         $this->addRecentUser($userId);
         $key = $this->generateCacheKey($event->visit->getType(), $userId);
-        $visits = Cache::get($key, new Collection());
-        $visits->prepend($event->visit);
-        $visits = $visits->take(10);
-        Cache::forever($key, $visits);
+        Cache::forever($key,
+            Cache::get($key, new Collection())
+                ->prepend($event->visit)
+                ->unique(function ($visit) {
+                    return $visit->getLink()->getUrl();
+                })
+                ->take(10)
+        );
     }
 
     protected function getRecentUsers(): array

--- a/src/RecentVisitsRepository.php
+++ b/src/RecentVisitsRepository.php
@@ -39,7 +39,7 @@ class RecentVisitsRepository implements RecentVisitsRepositoryContract
     {
         $key = $this->generateCacheKey($event->visit->getType());
         $visits = Cache::get($key, new Collection());
-        $visits->push($event->visit);
+        $visits->prepend($event->visit);
         Cache::forever($key, $visits);
     }
 

--- a/src/RecentVisitsRepository.php
+++ b/src/RecentVisitsRepository.php
@@ -49,7 +49,7 @@ class RecentVisitsRepository implements RecentVisitsRepositoryContract
                 ->unique(function ($visit) {
                     return $visit->getLink()->getUrl();
                 })
-                ->take(10)
+                ->take(max(config('kontour.max_recent_visits', [10])))
         );
     }
 

--- a/src/Widgets/PersonalRecentVisitsWidget.php
+++ b/src/Widgets/PersonalRecentVisitsWidget.php
@@ -36,6 +36,6 @@ class PersonalRecentVisitsWidget implements PersonalRecentVisitsWidgetContract
                 return $visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
             })
             ->sortByDesc->getDateTime()
-            ->take(10);
+            ->take(config('kontour.max_recent_visits.personal', 10));
     }
 }

--- a/src/Widgets/PersonalRecentVisitsWidget.php
+++ b/src/Widgets/PersonalRecentVisitsWidget.php
@@ -33,7 +33,8 @@ class PersonalRecentVisitsWidget implements PersonalRecentVisitsWidgetContract
     {
         return $this->repository->getShowVisits()->merge($this->repository->getEditVisits())
             ->filter(function ($visit) {
-                return $visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
+                return $visit->getUser()->is($this->adminUser())
+                and $visit->getLink()->isAuthorized($this->adminUser());
             })
             ->sortByDesc->getDateTime()
             ->take(config('kontour.max_recent_visits.personal', 10));

--- a/src/Widgets/PersonalRecentVisitsWidget.php
+++ b/src/Widgets/PersonalRecentVisitsWidget.php
@@ -31,12 +31,11 @@ class PersonalRecentVisitsWidget implements PersonalRecentVisitsWidgetContract
 
     private function getVisits()
     {
-        return $this->repository->getShowVisits()->merge($this->repository->getEditVisits())->filter(function ($visit) {
-            return $visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
-        })->unique(function ($visit) {
-            return $visit->getLink()->getUrl();
-        })->sortByDesc(function ($visit) {
-            return $visit->getDateTime();
-        });
+        return $this->repository->getShowVisits()->merge($this->repository->getEditVisits())
+            ->filter(function ($visit) {
+                return $visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
+            })
+            ->sortByDesc->getDateTime()
+            ->take(10);
     }
 }

--- a/src/Widgets/TeamRecentVisitsWidget.php
+++ b/src/Widgets/TeamRecentVisitsWidget.php
@@ -33,7 +33,8 @@ class TeamRecentVisitsWidget implements TeamRecentVisitsWidgetContract
     {
         return $this->repository->getEditVisits()
             ->filter(function ($visit) {
-                return !$visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
+                return !$visit->getUser()->is($this->adminUser())
+                and $visit->getLink()->isAuthorized($this->adminUser());
             })
             ->sortByDesc->getDateTime()
             ->take(config('kontour.max_recent_visits.team', 10));

--- a/src/Widgets/TeamRecentVisitsWidget.php
+++ b/src/Widgets/TeamRecentVisitsWidget.php
@@ -36,6 +36,6 @@ class TeamRecentVisitsWidget implements TeamRecentVisitsWidgetContract
                 return !$visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
             })
             ->sortByDesc->getDateTime()
-            ->take(10);
+            ->take(config('kontour.max_recent_visits.team', 10));
     }
 }

--- a/src/Widgets/TeamRecentVisitsWidget.php
+++ b/src/Widgets/TeamRecentVisitsWidget.php
@@ -3,11 +3,10 @@
 namespace Kontenta\Kontour\Widgets;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
 use Kontenta\Kontour\Concerns\ResolvesAdminUser;
-use Kontenta\Kontour\RecentVisitsRepository;
 use Kontenta\Kontour\Contracts\TeamRecentVisitsWidget as TeamRecentVisitsWidgetContract;
+use Kontenta\Kontour\RecentVisitsRepository;
 
 class TeamRecentVisitsWidget implements TeamRecentVisitsWidgetContract
 {
@@ -32,12 +31,11 @@ class TeamRecentVisitsWidget implements TeamRecentVisitsWidgetContract
 
     private function getVisits()
     {
-        return $this->repository->getEditVisits()->filter(function ($visit) {
-            return !$visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
-        })->unique(function ($visit) {
-            return $visit->getLink()->getUrl();
-        })->sortByDesc(function ($visit) {
-            return $visit->getDateTime();
-        });
+        return $this->repository->getEditVisits()
+            ->filter(function ($visit) {
+                return !$visit->getUser()->is($this->adminUser()) and $visit->getLink()->isAuthorized($this->adminUser());
+            })
+            ->sortByDesc->getDateTime()
+            ->take(10);
     }
 }


### PR DESCRIPTION
- Refactor visit cache storage to save a collection for each user, along with a cached array of all user ids.
- Add config for max number of visited links in widgets
- Remove duplicate links per user in cache storage instead of filtering duplicates in the widget