### PR TITLE
Improve form templates, again

### DIFF
--- a/resources/views/forms/checkbox.blade.php
+++ b/resources/views/forms/checkbox.blade.php
@@ -1,8 +1,1 @@
-<div>
-  @component('kontour::forms.elements.label', ['name' => $name, 'label' => $label ?? null, 'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name), 'labelAttributes' => $labelAttributes ?? []])
-    @slot('labelStart')
-      @include('kontour::forms.elements.checkbox', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
-    @endslot
-  @endcomponent
-  @include('kontour::forms.partials.errors')
-</div>
+@include('kontour::forms.groups.checkbox')

--- a/resources/views/forms/checkboxes.blade.php
+++ b/resources/views/forms/checkboxes.blade.php
@@ -1,8 +1,1 @@
-<fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
-  data-checked-checkboxes="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
->
-  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
-  <input type="hidden" name="{{ $name }}" value="">
-  @include('kontour::forms.partials.checkableOptions')
-  @include('kontour::forms.partials.errors')
-</fieldset>
+@include('kontour::forms.groups.checkboxes')

--- a/resources/views/forms/groups/checkbox.blade.php
+++ b/resources/views/forms/groups/checkbox.blade.php
@@ -1,8 +1,10 @@
-<div>
+<{{ $groupTag = $groupTag ?? 'div' }}
+  @include('kontour::forms.partials.groupAttributes')
+>
   @component('kontour::forms.elements.label', ['name' => $name, 'label' => $label ?? null, 'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name), 'labelAttributes' => $labelAttributes ?? []])
     @slot('labelStart')
       @include('kontour::forms.elements.checkbox', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
     @endslot
   @endcomponent
   @include('kontour::forms.partials.errors')
-</div>
+</{{ $groupTag }}>

--- a/resources/views/forms/groups/checkbox.blade.php
+++ b/resources/views/forms/groups/checkbox.blade.php
@@ -1,0 +1,8 @@
+<div>
+  @component('kontour::forms.elements.label', ['name' => $name, 'label' => $label ?? null, 'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name), 'labelAttributes' => $labelAttributes ?? []])
+    @slot('labelStart')
+      @include('kontour::forms.elements.checkbox', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+    @endslot
+  @endcomponent
+  @include('kontour::forms.partials.errors')
+</div>

--- a/resources/views/forms/groups/checkboxes.blade.php
+++ b/resources/views/forms/groups/checkboxes.blade.php
@@ -2,7 +2,7 @@
   data-checked-checkboxes="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
   @include('kontour::forms.partials.groupAttributes')
 >
-  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
+  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors'), 'labelAttributes' => $legendAttributes ?? []])
   <input type="hidden" name="{{ $name }}" value="">
   @include('kontour::forms.partials.checkableOptions')
   @include('kontour::forms.partials.errors')

--- a/resources/views/forms/groups/checkboxes.blade.php
+++ b/resources/views/forms/groups/checkboxes.blade.php
@@ -1,5 +1,6 @@
 <fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
   data-checked-checkboxes="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
+  @include('kontour::forms.partials.groupAttributes')
 >
   @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
   <input type="hidden" name="{{ $name }}" value="">

--- a/resources/views/forms/groups/checkboxes.blade.php
+++ b/resources/views/forms/groups/checkboxes.blade.php
@@ -1,0 +1,8 @@
+<fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
+  data-checked-checkboxes="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
+>
+  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
+  <input type="hidden" name="{{ $name }}" value="">
+  @include('kontour::forms.partials.checkableOptions')
+  @include('kontour::forms.partials.errors')
+</fieldset>

--- a/resources/views/forms/groups/input.blade.php
+++ b/resources/views/forms/groups/input.blade.php
@@ -1,0 +1,9 @@
+<div>
+  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  <div>
+    {{ $beforeControl ?? '' }}
+    @include('kontour::forms.elements.input', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+    {{ $afterControl ?? '' }}
+    @include('kontour::forms.partials.errors')
+  </div>
+</div>

--- a/resources/views/forms/groups/input.blade.php
+++ b/resources/views/forms/groups/input.blade.php
@@ -1,4 +1,6 @@
-<div>
+<{{ $groupTag = $groupTag ?? 'div' }}
+  @include('kontour::forms.partials.groupAttributes')
+>
   @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
   <div>
     {{ $beforeControl ?? '' }}
@@ -6,4 +8,4 @@
     {{ $afterControl ?? '' }}
     @include('kontour::forms.partials.errors')
   </div>
-</div>
+</{{ $groupTag }}>

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -1,0 +1,14 @@
+<div data-selected-options="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}">
+  <input type="hidden" name="{{ $name }}" value="">
+  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  <div>
+    {{ $beforeControl ?? '' }}
+    <select multiple
+      @include('kontour::forms.partials.inputAttributes', ['name' => $name . '[]', 'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+    >
+      @include('kontour::forms.partials.options')
+    </select>
+    {{ $afterControl ?? '' }}
+    @include('kontour::forms.partials.errors')
+  </div>
+</div>

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -1,4 +1,7 @@
-<div data-selected-options="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}">
+<{{ $groupTag = $groupTag ?? 'div' }}
+  data-selected-options="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
+  @include('kontour::forms.partials.groupAttributes')
+>
   <input type="hidden" name="{{ $name }}" value="">
   @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
   <div>
@@ -11,4 +14,4 @@
     {{ $afterControl ?? '' }}
     @include('kontour::forms.partials.errors')
   </div>
-</div>
+</{{ $groupTag }}>

--- a/resources/views/forms/groups/radiobuttons.blade.php
+++ b/resources/views/forms/groups/radiobuttons.blade.php
@@ -1,0 +1,7 @@
+<fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
+  data-checked-radio="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
+>
+  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
+  @include('kontour::forms.partials.checkableOptions')
+  @include('kontour::forms.partials.errors')
+</fieldset>

--- a/resources/views/forms/groups/radiobuttons.blade.php
+++ b/resources/views/forms/groups/radiobuttons.blade.php
@@ -1,5 +1,6 @@
 <fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
   data-checked-radio="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
+  @include('kontour::forms.partials.groupAttributes')
 >
   @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
   @include('kontour::forms.partials.checkableOptions')

--- a/resources/views/forms/groups/radiobuttons.blade.php
+++ b/resources/views/forms/groups/radiobuttons.blade.php
@@ -2,7 +2,7 @@
   data-checked-radio="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
   @include('kontour::forms.partials.groupAttributes')
 >
-  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
+  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors'), 'labelAttributes' => $legendAttributes ?? []])
   @include('kontour::forms.partials.checkableOptions')
   @include('kontour::forms.partials.errors')
 </fieldset>

--- a/resources/views/forms/groups/select.blade.php
+++ b/resources/views/forms/groups/select.blade.php
@@ -1,4 +1,7 @@
-<div data-selected-option="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}">
+<{{ $groupTag = $groupTag ?? 'div' }}
+  data-selected-option="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
+  @include('kontour::forms.partials.groupAttributes')
+>
   @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
   <div>
     {{ $beforeControl ?? '' }}
@@ -10,4 +13,4 @@
     {{ $afterControl ?? '' }}
     @include('kontour::forms.partials.errors')
   </div>
-</div>
+</{{ $groupTag }}>

--- a/resources/views/forms/groups/select.blade.php
+++ b/resources/views/forms/groups/select.blade.php
@@ -1,0 +1,13 @@
+<div data-selected-option="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}">
+  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  <div>
+    {{ $beforeControl ?? '' }}
+    <select
+      @include('kontour::forms.partials.inputAttributes', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+    >
+      @include('kontour::forms.partials.options')
+    </select>
+    {{ $afterControl ?? '' }}
+    @include('kontour::forms.partials.errors')
+  </div>
+</div>

--- a/resources/views/forms/groups/textarea.blade.php
+++ b/resources/views/forms/groups/textarea.blade.php
@@ -1,0 +1,11 @@
+<div>
+  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  <div>
+    {{ $beforeControl ?? '' }}
+    <textarea
+      @include('kontour::forms.partials.inputAttributes', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+    >{{ old($name, $value ?? $slot ?? $model[$name] ?? '') }}</textarea>
+    {{ $afterControl ?? '' }}
+    @include('kontour::forms.partials.errors')
+  </div>
+</div>

--- a/resources/views/forms/groups/textarea.blade.php
+++ b/resources/views/forms/groups/textarea.blade.php
@@ -1,4 +1,6 @@
-<div>
+<{{ $groupTag = $groupTag ?? 'div' }}
+  @include('kontour::forms.partials.groupAttributes')
+>
   @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
   <div>
     {{ $beforeControl ?? '' }}
@@ -8,4 +10,4 @@
     {{ $afterControl ?? '' }}
     @include('kontour::forms.partials.errors')
   </div>
-</div>
+</{{ $groupTag }}>

--- a/resources/views/forms/input.blade.php
+++ b/resources/views/forms/input.blade.php
@@ -1,9 +1,1 @@
-<div>
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
-  <div>
-    {{ $beforeControl ?? '' }}
-    @include('kontour::forms.elements.input', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
-    {{ $afterControl ?? '' }}
-    @include('kontour::forms.partials.errors')
-  </div>
-</div>
+@include('kontour::forms.groups.input')

--- a/resources/views/forms/multiselect.blade.php
+++ b/resources/views/forms/multiselect.blade.php
@@ -1,14 +1,1 @@
-<div data-selected-options="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}">
-  <input type="hidden" name="{{ $name }}" value="">
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
-  <div>
-    {{ $beforeControl ?? '' }}
-    <select multiple
-      @include('kontour::forms.partials.inputAttributes', ['name' => $name . '[]', 'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
-    >
-      @include('kontour::forms.partials.options')
-    </select>
-    {{ $afterControl ?? '' }}
-    @include('kontour::forms.partials.errors')
-  </div>
-</div>
+@include('kontour::forms.groups.multiselect')

--- a/resources/views/forms/partials/groupAttributes.blade.php
+++ b/resources/views/forms/partials/groupAttributes.blade.php
@@ -1,0 +1,5 @@
+@if(isset($groupAttributes) and is_iterable($groupAttributes))
+  @foreach($groupAttributes as $attributeName => $attributeValue)
+    @include('kontour::forms.partials.attribute')
+  @endforeach
+@endif

--- a/resources/views/forms/radiobuttons.blade.php
+++ b/resources/views/forms/radiobuttons.blade.php
@@ -1,7 +1,1 @@
-<fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
-  data-checked-radio="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
->
-  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors')])
-  @include('kontour::forms.partials.checkableOptions')
-  @include('kontour::forms.partials.errors')
-</fieldset>
+@include('kontour::forms.groups.radiobuttons')

--- a/resources/views/forms/select.blade.php
+++ b/resources/views/forms/select.blade.php
@@ -1,13 +1,1 @@
-<div data-selected-option="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}">
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
-  <div>
-    {{ $beforeControl ?? '' }}
-    <select
-      @include('kontour::forms.partials.inputAttributes', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
-    >
-      @include('kontour::forms.partials.options')
-    </select>
-    {{ $afterControl ?? '' }}
-    @include('kontour::forms.partials.errors')
-  </div>
-</div>
+@include('kontour::forms.groups.select')

--- a/resources/views/forms/textarea.blade.php
+++ b/resources/views/forms/textarea.blade.php
@@ -1,11 +1,1 @@
-<div>
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
-  <div>
-    {{ $beforeControl ?? '' }}
-    <textarea
-      @include('kontour::forms.partials.inputAttributes', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
-    >{{ old($name, $value ?? $slot ?? $model[$name] ?? '') }}</textarea>
-    {{ $afterControl ?? '' }}
-    @include('kontour::forms.partials.errors')
-  </div>
-</div>
+@include('kontour::forms.groups.textarea')


### PR DESCRIPTION
This PR further improves the reusability of form templates by breaking the logic out for each "group", consisting of a form control, its wrapper and label.

This makes it possible to just `@include` the group in a local project and send along/merge any label or control attributes one wants to add, e.g. bootstrap classes.