### PR TITLE
Skip authorization if ability is null

### DIFF
--- a/src/Concerns/AuthorizesAdminRequests.php
+++ b/src/Concerns/AuthorizesAdminRequests.php
@@ -53,11 +53,13 @@ trait AuthorizesAdminRequests
         string $linkDescription = null,
         $abilityArguments = []
     ): AdminLink {
-        [$ability, $abilityArguments] = $this->parseAbilityAndArguments($ability, $abilityArguments);
+        $link = AdminLink::create($linkName, url()->full(), $linkDescription);
 
-        $result = $this->authorizeForUser($this->adminUser(), $ability, $abilityArguments);
+        if (!is_null($ability)) {
+            $result = $this->authorizeForUser($this->adminUser(), $ability, $abilityArguments);
+            $link->registerAbilityForAuthorization($ability, $abilityArguments);
+        }
 
-        return AdminLink::create($linkName, url()->full(), $linkDescription)
-            ->registerAbilityForAuthorization($ability, $abilityArguments);
+        return $link;
     }
 }

--- a/src/Concerns/AuthorizesWithAbility.php
+++ b/src/Concerns/AuthorizesWithAbility.php
@@ -26,11 +26,11 @@ trait AuthorizesWithAbility
 
     /**
      * Register a policy or gate to be used for the authorization
-     * @param string $ability name from a Gate/Policy
+     * @param string|null $ability name from a Gate/Policy, or null to unset
      * @param array|mixed $arguments for the ability check, typically a model instance
      * @return $this
      */
-    public function registerAbilityForAuthorization(string $ability, $arguments = []): AuthorizesWithAbilityContract
+    public function registerAbilityForAuthorization(?string $ability, $arguments = []): AuthorizesWithAbilityContract
     {
         $this->authorizesWithAbilityName = $ability;
         $this->authorizesWithAbilityArguments = $arguments;

--- a/src/Contracts/AuthorizesWithAbility.php
+++ b/src/Contracts/AuthorizesWithAbility.php
@@ -8,11 +8,11 @@ interface AuthorizesWithAbility extends Authorizes
 {
     /**
      * Register a policy or gate to be used for the authorization
-     * @param string $ability name from a Gate/Policy
+     * @param string|null $ability name from a Gate/Policy, or null to unset
      * @param array|mixed $arguments for the ability check, typically a model instance
      * @return $this
      */
-    public function registerAbilityForAuthorization(string $ability, $arguments = []): AuthorizesWithAbility;
+    public function registerAbilityForAuthorization(?string $ability, $arguments = []): AuthorizesWithAbility;
 
     /**
      * Register a guard to be used for the authorization


### PR DESCRIPTION
Remove call to parseAbilityAndArguments as it only works directly in controller method anyway.

If the ability is not specified, skip the auth and just return the link, effectively just triggering the visited event.