### PR TITLE
Array inputs with dot-notation

### DIFF
--- a/resources/views/forms/elements/label.blade.php
+++ b/resources/views/forms/elements/label.blade.php
@@ -7,4 +7,4 @@
     @include('kontour::forms.partials.attribute')
   @endforeach
 @endif
->{{ $labelStart ?? '' }}{{ $label ?? ucfirst(Lang::has('validation.attributes.'.$name) ? Lang::trans('validation.attributes.'.$name) : str_replace('_', ' ', $name)) }}{{ $labelEnd ?? '' }}</{{ $labelTag }}>
+>{{ $labelStart ?? '' }}{{ $label ?? ucfirst(Lang::has('validation.attributes.'.$name) ? Lang::trans('validation.attributes.' . $name) : str_replace(['_', '.', '[]'], [' ', ' ', ''], $name)) }}{{ $labelEnd ?? '' }}</{{ $labelTag }}>

--- a/resources/views/forms/groups/checkbox.blade.php
+++ b/resources/views/forms/groups/checkbox.blade.php
@@ -1,9 +1,16 @@
 <{{ $groupTag = $groupTag ?? 'div' }}
   @include('kontour::forms.partials.groupAttributes')
 >
-  @component('kontour::forms.elements.label', ['name' => $name, 'label' => $label ?? null, 'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name), 'labelAttributes' => $labelAttributes ?? []])
+  @component('kontour::forms.elements.label', [
+    'name' => $name,
+    'label' => $label ?? null,
+    'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name),
+    'labelAttributes' => $labelAttributes ?? [],
+  ])
     @slot('labelStart')
-      @include('kontour::forms.elements.checkbox', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+      @include('kontour::forms.elements.checkbox', [
+        'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
+      ])
     @endslot
   @endcomponent
   @include('kontour::forms.partials.errors')

--- a/resources/views/forms/groups/checkboxes.blade.php
+++ b/resources/views/forms/groups/checkboxes.blade.php
@@ -2,7 +2,11 @@
   data-checked-checkboxes="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
   @include('kontour::forms.partials.groupAttributes')
 >
-  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors'), 'labelAttributes' => $legendAttributes ?? []])
+  @include('kontour::forms.elements.label', [
+    'labelTag' => 'legend',
+    'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors'),
+    'labelAttributes' => $legendAttributes ?? [],
+  ])
   <input type="hidden" name="{{ $name }}" value="">
   @include('kontour::forms.partials.checkableOptions')
   @include('kontour::forms.partials.errors')

--- a/resources/views/forms/groups/input.blade.php
+++ b/resources/views/forms/groups/input.blade.php
@@ -1,10 +1,14 @@
 <{{ $groupTag = $groupTag ?? 'div' }}
   @include('kontour::forms.partials.groupAttributes')
 >
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  @include('kontour::forms.label', [
+    'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name),
+  ])
   <div>
     {{ $beforeControl ?? '' }}
-    @include('kontour::forms.elements.input', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+    @include('kontour::forms.elements.input', [
+      'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
+    ])
     {{ $afterControl ?? '' }}
     @include('kontour::forms.partials.errors')
   </div>

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -7,7 +7,7 @@
   <div>
     {{ $beforeControl ?? '' }}
     <select multiple
-      @include('kontour::forms.partials.inputAttributes', ['name' => $name . '[]', 'errorsKeys' => $errorsKeys = $name, 'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+      @include('kontour::forms.partials.inputAttributes', ['name' => $name . '[]', 'errorsKeys' => $errorsKeys = $errorsKeys ?? [$name, $name . '.*'], 'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
     >
       @include('kontour::forms.partials.options')
     </select>

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -3,11 +3,17 @@
   @include('kontour::forms.partials.groupAttributes')
 >
   <input type="hidden" name="{{ $name }}" value="">
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  @include('kontour::forms.label', [
+    'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name),
+  ])
   <div>
     {{ $beforeControl ?? '' }}
     <select multiple
-      @include('kontour::forms.partials.inputAttributes', ['name' => $name . '[]', 'errorsKeys' => $errorsKeys = $errorsKeys ?? [$name, $name . '.*'], 'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+      @include('kontour::forms.partials.inputAttributes', [
+        'name' => $name . '[]',
+        'errorsKeys' => $errorsKeys = $errorsKeys ?? [$name, $name . '.*'],
+        'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
+      ])
     >
       @include('kontour::forms.partials.options')
     </select>

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -7,7 +7,7 @@
   <div>
     {{ $beforeControl ?? '' }}
     <select multiple
-      @include('kontour::forms.partials.inputAttributes', ['name' => $name . '[]', 'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+      @include('kontour::forms.partials.inputAttributes', ['name' => $name . '[]', 'errorsKeys' => $errorsKeys = $name, 'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
     >
       @include('kontour::forms.partials.options')
     </select>

--- a/resources/views/forms/groups/radiobuttons.blade.php
+++ b/resources/views/forms/groups/radiobuttons.blade.php
@@ -2,7 +2,11 @@
   data-checked-radio="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
   @include('kontour::forms.partials.groupAttributes')
 >
-  @include('kontour::forms.elements.label', ['labelTag' => 'legend', 'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors'), 'labelAttributes' => $legendAttributes ?? []])
+  @include('kontour::forms.elements.label', [
+    'labelTag' => 'legend',
+    'errorsId' => $errorsId = $groupId . ($errorsSuffix ?? 'Errors'),
+    'labelAttributes' => $legendAttributes ?? [],
+  ])
   @include('kontour::forms.partials.checkableOptions')
   @include('kontour::forms.partials.errors')
 </fieldset>

--- a/resources/views/forms/groups/select.blade.php
+++ b/resources/views/forms/groups/select.blade.php
@@ -2,11 +2,15 @@
   data-selected-option="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
   @include('kontour::forms.partials.groupAttributes')
 >
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  @include('kontour::forms.label', [
+    'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name),
+  ])
   <div>
     {{ $beforeControl ?? '' }}
     <select
-      @include('kontour::forms.partials.inputAttributes', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+      @include('kontour::forms.partials.inputAttributes', [
+        'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
+      ])
     >
       @include('kontour::forms.partials.options')
     </select>

--- a/resources/views/forms/groups/textarea.blade.php
+++ b/resources/views/forms/groups/textarea.blade.php
@@ -1,11 +1,15 @@
 <{{ $groupTag = $groupTag ?? 'div' }}
   @include('kontour::forms.partials.groupAttributes')
 >
-  @include('kontour::forms.label', ['controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name)])
+  @include('kontour::forms.label', [
+    'controlId' => $controlId = $controlId ?? (($idPrefix ?? '') . $name),
+  ])
   <div>
     {{ $beforeControl ?? '' }}
     <textarea
-      @include('kontour::forms.partials.inputAttributes', ['errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors')])
+      @include('kontour::forms.partials.inputAttributes', [
+        'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
+      ])
     >{{ old($name, $value ?? $slot ?? $model[$name] ?? '') }}</textarea>
     {{ $afterControl ?? '' }}
     @include('kontour::forms.partials.errors')

--- a/resources/views/forms/partials/attribute.blade.php
+++ b/resources/views/forms/partials/attribute.blade.php
@@ -5,7 +5,7 @@
     {{ $attributeName }}
   @endif
 @elseif(is_array($attributeValue))
-  {{ $attributeName }}="{{ implode(' ', array_flatten($attributeValue)) }}"
+  {{ $attributeName }}="{{ implode(' ', \Illuminate\Support\Arr::flatten($attributeValue)) }}"
 @else
   {{ $attributeName }}="{{ $attributeValue }}"
 @endif

--- a/resources/views/forms/partials/checkableOption.blade.php
+++ b/resources/views/forms/partials/checkableOption.blade.php
@@ -1,11 +1,20 @@
-@component('kontour::forms.elements.label', ['label' => $option_display, 'controlId' => $controlId = $groupId . '[' . $option_value . ']', 'labelAttributes' => $labelAttributes ?? []])
+@component('kontour::forms.elements.label', [
+    'label' => $option_display,
+    'controlId' => $controlId = $groupId . '[' . $option_value . ']',
+    'labelAttributes' => $labelAttributes ?? [],
+  ])
   @slot('labelStart')
     <input type="{{ is_array($selected) ? 'checkbox' : 'radio' }}"
       value="{{ $option_value }}"
       @if(is_array($selected) ? in_array(strval($option_value), $selected) : $selected == strval($option_value))
         checked
       @endif
-      @include('kontour::forms.partials.inputAttributes', ['name' => is_array($selected) ? $name . '[]' : $name, 'errorsKeys' => $name])
+      @include('kontour::forms.partials.inputAttributes', [
+        'name' => is_array($selected) ? $name . '[]' : $name,
+      ])
     >
   @endslot
 @endcomponent
+@if($errorsKeys == $optionErrorKey)
+  @include('kontour::forms.partials.errors')
+@endif

--- a/resources/views/forms/partials/checkableOption.blade.php
+++ b/resources/views/forms/partials/checkableOption.blade.php
@@ -5,7 +5,7 @@
       @if(is_array($selected) ? in_array(strval($option_value), $selected) : $selected == strval($option_value))
         checked
       @endif
-      @include('kontour::forms.partials.inputAttributes', ['name' => is_array($selected) ? $name . '[]' : $name])
+      @include('kontour::forms.partials.inputAttributes', ['name' => is_array($selected) ? $name . '[]' : $name, 'errorsKeys' => $name])
     >
   @endslot
 @endcomponent

--- a/resources/views/forms/partials/checkableOptions.blade.php
+++ b/resources/views/forms/partials/checkableOptions.blade.php
@@ -3,7 +3,14 @@
   <fieldset><legend>{{ $legend }}</legend>
   @endif
   @foreach($legend ? $option_display : [$option_value => $option_display] as $option_value => $option_display)
-    @include('kontour::forms.partials.checkableOption', ['controlId' => $controlId = $groupId . '[' . $option_value . ']'])
+    @include('kontour::forms.partials.checkableOption', [
+      'optionIndex' => $optionIndex = isset($optionIndex) ? $optionIndex + 1 : 0,
+      'optionErrorKey' => $optionErrorKey = $name . '.' . $optionIndex,
+      'controlId' => $controlId = $groupId . '[' . $option_value . ']',
+      'errorsId' => $errors->has($optionErrorKey) ? $errorsId . $optionIndex : $errorsId,
+      'errorsKeys' => $errors->has($optionErrorKey) ? $optionErrorKey : ($errorsKeys ?? $name),
+    ])
+    {{ $optionErrorKey }}
   @endforeach
   @if($legend)
   </fieldset>

--- a/resources/views/forms/partials/checkableOptions.blade.php
+++ b/resources/views/forms/partials/checkableOptions.blade.php
@@ -6,7 +6,6 @@
     @include('kontour::forms.partials.checkableOption', [
       'optionIndex' => $optionIndex = isset($optionIndex) ? $optionIndex + 1 : 0,
       'optionErrorKey' => $optionErrorKey = $name . '.' . $optionIndex,
-      'controlId' => $controlId = $groupId . '[' . $option_value . ']',
       'errorsId' => $errors->has($optionErrorKey) ? $errorsId . '[' . $optionIndex . ']' : $errorsId,
       'errorsKeys' => $errors->has($optionErrorKey) ? $optionErrorKey : ($errorsKeys ?? $name),
     ])

--- a/resources/views/forms/partials/checkableOptions.blade.php
+++ b/resources/views/forms/partials/checkableOptions.blade.php
@@ -7,10 +7,9 @@
       'optionIndex' => $optionIndex = isset($optionIndex) ? $optionIndex + 1 : 0,
       'optionErrorKey' => $optionErrorKey = $name . '.' . $optionIndex,
       'controlId' => $controlId = $groupId . '[' . $option_value . ']',
-      'errorsId' => $errors->has($optionErrorKey) ? $errorsId . $optionIndex : $errorsId,
+      'errorsId' => $errors->has($optionErrorKey) ? $errorsId . '[' . $optionIndex . ']' : $errorsId,
       'errorsKeys' => $errors->has($optionErrorKey) ? $optionErrorKey : ($errorsKeys ?? $name),
     ])
-    {{ $optionErrorKey }}
   @endforeach
   @if($legend)
   </fieldset>

--- a/resources/views/forms/partials/errors.blade.php
+++ b/resources/views/forms/partials/errors.blade.php
@@ -1,7 +1,7 @@
 @if($errors->hasAny($errorsKeys = $errorsKeys ?? $name))
   <ul id="{{ $errorsId }}">
     @foreach(\Illuminate\Support\Arr::wrap($errorsKeys) as $key)
-      @foreach($errors->get($key) as $message)
+      @foreach(\Illuminate\Support\Arr::flatten($errors->get($key)) as $message)
         <li>{{ $message }}</li>
       @endforeach
     @endforeach

--- a/resources/views/forms/partials/errors.blade.php
+++ b/resources/views/forms/partials/errors.blade.php
@@ -1,7 +1,9 @@
-@if($errors->has($name))
-<ul id="{{ $errorsId }}">
-@foreach($errors->get($name) as $message)
-  <li>{{ $message }}</li>
-@endforeach
-</ul>
+@if($errors->hasAny($errorsKeys = $errorsKeys ?? $name))
+  <ul id="{{ $errorsId }}">
+    @foreach(\Illuminate\Support\Arr::wrap($errorsKeys) as $key)
+      @foreach($errors->get($key) as $message)
+        <li>{{ $message }}</li>
+      @endforeach
+    @endforeach
+  </ul>
 @endif

--- a/resources/views/forms/partials/inputAttributes.blade.php
+++ b/resources/views/forms/partials/inputAttributes.blade.php
@@ -1,6 +1,6 @@
 name="{{ $name }}"
 id="{{ $controlId }}"
-@if($errors->has(str_replace('[]', '', $name)))
+@if($errors->hasAny($errorsKeys ?? $name))
   aria-invalid="true"
   aria-describedby="{{ $errorsId }}"
 @elseif(isset($ariaDescribedById))

--- a/resources/views/forms/partials/inputAttributes.blade.php
+++ b/resources/views/forms/partials/inputAttributes.blade.php
@@ -1,4 +1,4 @@
-name="{{ $name }}"
+name="{{ preg_replace('/\.([^\.]*)/', '[$1]', $name) }}"
 id="{{ $controlId }}"
 @if($errors->hasAny($errorsKeys ?? $name))
   aria-invalid="true"

--- a/tests/Feature/FormViewTests/CheckboxesTest.php
+++ b/tests/Feature/FormViewTests/CheckboxesTest.php
@@ -165,8 +165,8 @@ class CheckboxesTest extends IntegrationTest
             ]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors1"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors1"[\S\s]*>[\S\s]*Error for option[\S\s]*<\/\1>/', $output);
+        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors\[1]"[\S\s]*>/', $output);
+        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors\[1]"[\S\s]*>[\S\s]*Error for option[\S\s]*<\/\1>/', $output);
 
         $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);

--- a/tests/Feature/FormViewTests/CheckboxesTest.php
+++ b/tests/Feature/FormViewTests/CheckboxesTest.php
@@ -154,6 +154,24 @@ class CheckboxesTest extends IntegrationTest
         $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
+    public function test_error_option_referencing_error_element_with_errors()
+    {
+        $output = View::make('kontour::forms.checkboxes', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag([
+                'test.1' => ['Error for option'],
+                'test' => ['A message'],
+            ]),
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors1"[\S\s]*>/', $output);
+        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors1"[\S\s]*>[\S\s]*Error for option[\S\s]*<\/\1>/', $output);
+
+        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+    }
+
     public function test_custom_errors_id_suffix()
     {
         $output = View::make('kontour::forms.checkboxes', [

--- a/tests/Feature/FormViewTests/InputAttributesTest.php
+++ b/tests/Feature/FormViewTests/InputAttributesTest.php
@@ -19,6 +19,17 @@ class InputAttributesTest extends IntegrationTest
         $this->assertRegExp('/name="testName"/', $output);
     }
 
+    public function test_name_in_dot_notation()
+    {
+        $output = View::make('kontour::forms.partials.inputAttributes', [
+            'name' => 'test.name.in.dot.notation',
+            'controlId' => 'testId',
+            'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertRegExp('/name="test\[name]\[in]\[dot]\[notation]"/', $output);
+    }
+
     public function test_has_control_id()
     {
         $output = View::make('kontour::forms.partials.inputAttributes', [

--- a/tests/Feature/FormViewTests/InputTest.php
+++ b/tests/Feature/FormViewTests/InputTest.php
@@ -137,6 +137,17 @@ class InputTest extends IntegrationTest
         $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
+    public function test_dot_notation_error_input_referencing_error_element_with_errors()
+    {
+        $output = View::make('kontour::forms.input', [
+            'name' => 'test.dot.notation',
+            'errors' => new MessageBag(['test.dot.notation' => ['A message']]),
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*aria-describedby="test.dot.notationErrors"[\S\s]*>/', $output);
+        $this->assertRegExp('/<(\S*)[\S\s]*id="test.dot.notationErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+    }
+
     public function test_custom_errors_id_suffix()
     {
         $output = View::make('kontour::forms.input', [

--- a/tests/Feature/FormViewTests/LabelTest.php
+++ b/tests/Feature/FormViewTests/LabelTest.php
@@ -32,9 +32,9 @@ class LabelTest extends IntegrationTest
 
     public function test_generated_label_is_humanized()
     {
-        $output = View::make('kontour::forms.label', ['name' => 'test_input'])->render();
+        $output = View::make('kontour::forms.label', ['name' => 'test_input.with.dot.notation[]'])->render();
 
-        $this->assertRegExp('/<label[\S\s]*>Test input<\/label>/', $output);
+        $this->assertRegExp('/<label[\S\s]*>Test input with dot notation<\/label>/', $output);
     }
 
     public function test_validation_attribute_is_used_for_label()

--- a/tests/Feature/FormViewTests/MultiselectTest.php
+++ b/tests/Feature/FormViewTests/MultiselectTest.php
@@ -181,4 +181,16 @@ class MultiselectTest extends IntegrationTest
         $this->assertRegExp('/<select[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_error_on_option_referencing_error_element_with_errors()
+    {
+        $output = View::make('kontour::forms.multiselect', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag(['test.1' => 'A message']),
+        ])->render();
+
+        $this->assertRegExp('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+    }
 }


### PR DESCRIPTION
This PR makes possible to use the form templates with dot-notation to nest form data in arrays.

You can now `@include` an input with `'name' => 'dot.notation'` and that will result in `name="dot[notation]"` being printed in HTML with a nice humanized label "Dot notation". The error MessageBag in Laravel already references inputs with this notation, so that keeps working as usual.

It also makes sure an input can display errors from more than one validation field which is useful for `multiple` type inputs where you want to print any errors related to the `field` but also to `field.*` next to the same input.

The PR also adds a little functionality for checkbox multiselects, where if a specific checkbox has an error, then that error is printed next to it, and if not each checkbox gets connected to the main error element for the whole `<fieldset>` (as before).