### PR TITLE
Input autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,19 @@ This is actually a good pattern for scoping variables to one of the forms on you
 @include('my_form_partial', ['errors' => $errors->my_form_bag, 'model' => $user])
 ```
 
+The `id` attribute is set automatically on created elements that need it,
+and it's usually derieved from the `$name` variable.
+If you get an id conflict on a page where two inputs may have the same name,
+e.g. in different forms, different `$idPrefix` can be passed along to the templates
+to make the ids unique.
+
+#### Input autofocus
+
 The variable `$autofocusControlId` can be set to the id of the input you want to `autofocus`,
 usually the first field with errors.
 If no `$idPrefix` is set, this conveniently corresponds to the keys in Laravel's `$errors` bag.
+It's best to set it as high up as possible in the view, before any forms are included.
+You could even set in the controller and pass it along to the view.
 
 ### Button templates
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,23 @@ generate form inputs along with labels and validation feedback.
 </form>
 ```
 
+The form views will prefill inputs with data from a `$model` variable if it is set in the blade view,
+so you may just pass an Eloquent model to the view.
+
+[Laravel's `$errors` bag](https://laravel.com/docs/5.8/validation#quick-displaying-the-validation-errors)
+is used to display errors for inputs.
+If you have [named error bags](https://laravel.com/docs/5.8/validation#named-error-bags) in your view,
+you can put one of those bags into the `$errors` variable by including a partial view.
+This is actually a good pattern for scoping variables to one of the forms on your page, if you have more than one.
+
+```php
+@include('my_form_partial', ['errors' => $errors->my_form_bag, 'model' => $user])
+```
+
+The variable `$autofocusControlId` can be set to the id of the input you want to `autofocus`,
+usually the first field with errors.
+If no `$idPrefix` is set, this conveniently corresponds to the keys in Laravel's `$errors` bag.
+
 ### Button templates
 
 [The button views](https://github.com/kontenta/kontour/tree/master/resources/views/buttons)

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -13,7 +13,6 @@
         'name' => $name . '[]',
         'errorsKeys' => $errorsKeys = $errorsKeys ?? [$name, $name . '.*'],
         'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
-        'autofocusInputName' => !empty($autofocusInputName) and $autofocusInputName == $name ? $name . '[]' : null,
       ])
     >
       @include('kontour::forms.partials.options')

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -13,6 +13,7 @@
         'name' => $name . '[]',
         'errorsKeys' => $errorsKeys = $errorsKeys ?? [$name, $name . '.*'],
         'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
+        'autofocusInputName' => !empty($autofocusInputName) and $autofocusInputName == $name ? $name . '[]' : null,
       ])
     >
       @include('kontour::forms.partials.options')

--- a/resources/views/forms/partials/checkableOption.blade.php
+++ b/resources/views/forms/partials/checkableOption.blade.php
@@ -11,6 +11,7 @@
       @endif
       @include('kontour::forms.partials.inputAttributes', [
         'name' => is_array($selected) ? $name . '[]' : $name,
+        'autofocusControlId' => empty($autofocusControlId) ? null : ($autofocusControlId == $groupId ? $autofocusControlId . '.0' : $autofocusControlId),
       ])
     >
   @endslot

--- a/resources/views/forms/partials/checkableOption.blade.php
+++ b/resources/views/forms/partials/checkableOption.blade.php
@@ -1,6 +1,6 @@
 @component('kontour::forms.elements.label', [
     'label' => $option_display,
-    'controlId' => $controlId = $groupId . '[' . $option_value . ']',
+    'controlId' => $controlId = $groupId . '.' . $optionIndex,
     'labelAttributes' => $labelAttributes ?? [],
   ])
   @slot('labelStart')

--- a/resources/views/forms/partials/checkableOptions.blade.php
+++ b/resources/views/forms/partials/checkableOptions.blade.php
@@ -6,7 +6,7 @@
     @include('kontour::forms.partials.checkableOption', [
       'optionIndex' => $optionIndex = isset($optionIndex) ? $optionIndex + 1 : 0,
       'optionErrorKey' => $optionErrorKey = $name . '.' . $optionIndex,
-      'errorsId' => $errors->has($optionErrorKey) ? $errorsId . '[' . $optionIndex . ']' : $errorsId,
+      'errorsId' => $errors->has($optionErrorKey) ? $errorsId . '.' . $optionIndex : $errorsId,
       'errorsKeys' => $errors->has($optionErrorKey) ? $optionErrorKey : ($errorsKeys ?? $name),
     ])
   @endforeach

--- a/resources/views/forms/partials/inputAttributes.blade.php
+++ b/resources/views/forms/partials/inputAttributes.blade.php
@@ -6,7 +6,7 @@ id="{{ $controlId }}"
 @elseif(isset($ariaDescribedById))
   aria-describedby="{{ $ariaDescribedById }}"
 @endif
-@if(!empty($autofocusInputName) and $autofocusInputName == $name)
+@if(!empty($autofocusControlId) and $autofocusControlId == $controlId)
   autofocus
 @endif
 @if(isset($controlAttributes) and is_iterable($controlAttributes))

--- a/resources/views/forms/partials/inputAttributes.blade.php
+++ b/resources/views/forms/partials/inputAttributes.blade.php
@@ -6,6 +6,9 @@ id="{{ $controlId }}"
 @elseif(isset($ariaDescribedById))
   aria-describedby="{{ $ariaDescribedById }}"
 @endif
+@if(!empty($autofocusInputName) and $autofocusInputName == $name)
+  autofocus
+@endif
 @if(isset($controlAttributes) and is_iterable($controlAttributes))
   @foreach($controlAttributes as $attributeName => $attributeValue)
     @include('kontour::partials.attribute')

--- a/tests/Feature/FormViewTests/CheckboxTest.php
+++ b/tests/Feature/FormViewTests/CheckboxTest.php
@@ -167,7 +167,7 @@ class CheckboxTest extends IntegrationTest
         $output = View::make('kontour::forms.checkbox', [
             'name' => 'test',
             'errors' => new MessageBag,
-            'autofocusInputName' => 'test',
+            'autofocusControlId' => 'test',
         ])->render();
 
         $this->assertRegExp('/<input[\S\s]*autofocus[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/CheckboxTest.php
+++ b/tests/Feature/FormViewTests/CheckboxTest.php
@@ -161,4 +161,15 @@ class CheckboxTest extends IntegrationTest
         $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_autofocus()
+    {
+        $output = View::make('kontour::forms.checkbox', [
+            'name' => 'test',
+            'errors' => new MessageBag,
+            'autofocusInputName' => 'test',
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*autofocus[\S\s]*>/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/CheckboxesTest.php
+++ b/tests/Feature/FormViewTests/CheckboxesTest.php
@@ -165,8 +165,8 @@ class CheckboxesTest extends IntegrationTest
             ]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors\[1]"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors\[1]"[\S\s]*>[\S\s]*Error for option[\S\s]*<\/\1>/', $output);
+        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors\.1"[\S\s]*>/', $output);
+        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors\.1"[\S\s]*>[\S\s]*Error for option[\S\s]*<\/\1>/', $output);
 
         $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);

--- a/tests/Feature/FormViewTests/CheckboxesTest.php
+++ b/tests/Feature/FormViewTests/CheckboxesTest.php
@@ -184,4 +184,30 @@ class CheckboxesTest extends IntegrationTest
         $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_autofocus_on_first_option()
+    {
+        $output = View::make('kontour::forms.checkboxes', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag,
+            'autofocusControlId' => 'test',
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertNotRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+    }
+
+    public function test_autofocus_on_specific_option()
+    {
+        $output = View::make('kontour::forms.checkboxes', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag,
+            'autofocusControlId' => 'test.1',
+        ])->render();
+
+        $this->assertNotRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>[\S\s]*<input/', $output);
+        $this->assertRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/InputAttributesTest.php
+++ b/tests/Feature/FormViewTests/InputAttributesTest.php
@@ -132,4 +132,28 @@ class InputAttributesTest extends IntegrationTest
         $this->assertRegExp('/a="b"\s*boolean\s*true\s*b="false"\s*c="0"/', $output);
         $this->assertNotRegExp('/\sfalse\s/', $output);
     }
+
+    public function test_can_have_autofocus()
+    {
+        $output = View::make('kontour::forms.partials.inputAttributes', [
+            'name' => 'testName',
+            'controlId' => 'testId',
+            'errors' => new MessageBag,
+            'autofocusInputName' => 'testName',
+        ])->render();
+
+        $this->assertRegExp('/autofocus/', $output);
+    }
+
+    public function test_other_element_can_have_autofocus()
+    {
+        $output = View::make('kontour::forms.partials.inputAttributes', [
+            'name' => 'testName',
+            'controlId' => 'testId',
+            'errors' => new MessageBag,
+            'autofocusInputName' => 'otherName',
+        ])->render();
+
+        $this->assertNotRegExp('/autofocus/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/InputAttributesTest.php
+++ b/tests/Feature/FormViewTests/InputAttributesTest.php
@@ -139,7 +139,7 @@ class InputAttributesTest extends IntegrationTest
             'name' => 'testName',
             'controlId' => 'testId',
             'errors' => new MessageBag,
-            'autofocusInputName' => 'testName',
+            'autofocusControlId' => 'testId',
         ])->render();
 
         $this->assertRegExp('/autofocus/', $output);
@@ -151,7 +151,7 @@ class InputAttributesTest extends IntegrationTest
             'name' => 'testName',
             'controlId' => 'testId',
             'errors' => new MessageBag,
-            'autofocusInputName' => 'otherName',
+            'autofocusControlId' => 'otherId',
         ])->render();
 
         $this->assertNotRegExp('/autofocus/', $output);

--- a/tests/Feature/FormViewTests/InputTest.php
+++ b/tests/Feature/FormViewTests/InputTest.php
@@ -159,4 +159,15 @@ class InputTest extends IntegrationTest
         $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_autofocus()
+    {
+        $output = View::make('kontour::forms.input', [
+            'name' => 'test',
+            'errors' => new MessageBag,
+            'autofocusInputName' => 'test',
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*autofocus[\S\s]*>/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/InputTest.php
+++ b/tests/Feature/FormViewTests/InputTest.php
@@ -165,7 +165,7 @@ class InputTest extends IntegrationTest
         $output = View::make('kontour::forms.input', [
             'name' => 'test',
             'errors' => new MessageBag,
-            'autofocusInputName' => 'test',
+            'autofocusControlId' => 'test',
         ])->render();
 
         $this->assertRegExp('/<input[\S\s]*autofocus[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/MultiselectTest.php
+++ b/tests/Feature/FormViewTests/MultiselectTest.php
@@ -200,7 +200,7 @@ class MultiselectTest extends IntegrationTest
             'name' => 'test',
             'options' => ['a' => 'A', 'b' => 'B'],
             'errors' => new MessageBag,
-            'autofocusInputName' => 'test',
+            'autofocusControlId' => 'test',
         ])->render();
 
         $this->assertRegExp('/<select[\S\s]*autofocus[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/MultiselectTest.php
+++ b/tests/Feature/FormViewTests/MultiselectTest.php
@@ -193,4 +193,16 @@ class MultiselectTest extends IntegrationTest
         $this->assertRegExp('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_autofocus()
+    {
+        $output = View::make('kontour::forms.multiselect', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag,
+            'autofocusInputName' => 'test',
+        ])->render();
+
+        $this->assertRegExp('/<select[\S\s]*autofocus[\S\s]*>/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/RadiobuttonsTest.php
+++ b/tests/Feature/FormViewTests/RadiobuttonsTest.php
@@ -131,4 +131,30 @@ class RadiobuttonsTest extends IntegrationTest
         $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_autofocus_on_first_option()
+    {
+        $output = View::make('kontour::forms.radiobuttons', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag,
+            'autofocusControlId' => 'test',
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertNotRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+    }
+
+    public function test_autofocus_on_specific_option()
+    {
+        $output = View::make('kontour::forms.radiobuttons', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag,
+            'autofocusControlId' => 'test.1',
+        ])->render();
+
+        $this->assertNotRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>[\S\s]*<input/', $output);
+        $this->assertRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -145,4 +145,16 @@ class SelectTest extends IntegrationTest
         $this->assertRegExp('/<select[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_autofocus()
+    {
+        $output = View::make('kontour::forms.select', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag,
+            'autofocusInputName' => 'test',
+        ])->render();
+
+        $this->assertRegExp('/<select[\S\s]*autofocus[\S\s]*>/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -152,7 +152,7 @@ class SelectTest extends IntegrationTest
             'name' => 'test',
             'options' => ['a' => 'A', 'b' => 'B'],
             'errors' => new MessageBag,
-            'autofocusInputName' => 'test',
+            'autofocusControlId' => 'test',
         ])->render();
 
         $this->assertRegExp('/<select[\S\s]*autofocus[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/TextareaTest.php
+++ b/tests/Feature/FormViewTests/TextareaTest.php
@@ -114,4 +114,15 @@ class TextareaTest extends IntegrationTest
         $this->assertRegExp('/<textarea[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
         $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
+
+    public function test_autofocus()
+    {
+        $output = View::make('kontour::forms.textarea', [
+            'name' => 'test',
+            'errors' => new MessageBag,
+            'autofocusInputName' => 'test',
+        ])->render();
+
+        $this->assertRegExp('/<textarea[\S\s]*autofocus[\S\s]*>/', $output);
+    }
 }

--- a/tests/Feature/FormViewTests/TextareaTest.php
+++ b/tests/Feature/FormViewTests/TextareaTest.php
@@ -120,7 +120,7 @@ class TextareaTest extends IntegrationTest
         $output = View::make('kontour::forms.textarea', [
             'name' => 'test',
             'errors' => new MessageBag,
-            'autofocusInputName' => 'test',
+            'autofocusControlId' => 'test',
         ])->render();
 
         $this->assertRegExp('/<textarea[\S\s]*autofocus[\S\s]*>/', $output);


### PR DESCRIPTION
This PR makes it possible to declare an `$autofocusControlId` for a form and that input (only) will get the autofocus attribute.

To get there I also switched from generating html ids like `test[a_value]` to `test.0` so that the id's correspond to the keys in Laravel's error bag.

Closes #67 