### PR TITLE
Use message widget in password reset

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -5,12 +5,7 @@
 @section('kontourMain')
   <header>{{ __('Reset Password') }}</header>
 
-  {{-- TODO: Use the MessageWidget instead of hard coded alert from session --}}
-  @if (session('status'))
-    <div class="alert alert-success" role="alert">
-      {{ session('status') }}
-    </div>
-  @endif
+  {{ $messageWidget }}
 
   <form method="POST" action="{{ route('kontour.password.email') }}">
     @csrf

--- a/src/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/src/Http/Controllers/Auth/ForgotPasswordController.php
@@ -2,11 +2,12 @@
 
 namespace Kontenta\Kontour\Http\Controllers\Auth;
 
-use Kontenta\Kontour\Contracts\AdminGuestMiddleware;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Password;
+use Kontenta\Kontour\Contracts\AdminGuestMiddleware;
+use Kontenta\Kontour\Contracts\MessageWidget;
 
 class ForgotPasswordController extends Controller
 {
@@ -28,9 +29,10 @@ class ForgotPasswordController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function showLinkRequestForm()
+    public function showLinkRequestForm(MessageWidget $messageWidget)
     {
-        return view('kontour::auth.passwords.email');
+        $messageWidget->addFromSession();
+        return view('kontour::auth.passwords.email', compact('messageWidget'));
     }
 
     /**

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -51,6 +51,10 @@ class PasswordResetTest extends IntegrationTest
             }
         );
 
+        $response = $this->get(route('kontour.password.request'));
+
+        $response->assertSeeText(trans(\Illuminate\Support\Facades\Password::RESET_LINK_SENT));
+
         $response = $this->get(route('kontour.password.reset', $token));
 
         $response->assertSuccessful();


### PR DESCRIPTION
This PR makes use of the `MessageWidget` to display status message to user after password reset email has been sent.

Tests have been updated to make sure the message is displaying properly.