### PR TITLE
Time tag template

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,6 +26,11 @@
 If you want your own local configuration for phpunit,
 copy the file `phpunit.xml.dist` to `phpunit.xml` and modify the latter to your needs.
 
+### Test logs
+
+Any Laravel log messages generated during testing can be found in the
+`vendor/orchestra/testbench-dusk/laravel/storage/logs` directory.
+
 ### Testing with different versions
 
 [Travis CI](https://travis-ci.org/kontenta/kontour) is set up to run tests

--- a/README.md
+++ b/README.md
@@ -257,6 +257,24 @@ as well as a "generic" button, and a "link"-like button.
 
 There's also a logout button and hamburger menu button.
 
+### Time templates
+
+There's a [view](https://github.com/kontenta/kontour/tree/master/resources/views/elements/time.blade.php)
+for rendering [`<time>` tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)
+to which you supply a [`Carbon`](https://carbon.nesbot.com)
+`$carbon` variable and it prints a proper `datetime` atom string attribute
+and by default a human readable time difference.
+
+```php
+@include('kontour::elements.time', ['carbon' => \Carbon\Carbon::now()])
+```
+
+You may also pass a `$format` string to display the tag contents in a specific format
+instad of the default relative time.
+If you pass `['format' => true]` the default format from Kontour's
+[config file](https://github.com/kontenta/kontour/blob/master/config/kontour.php)
+will be used.
+
 ## Adding menu items
 
 Usually adding menu items is done in a service provider's boot method:

--- a/config/kontour.php
+++ b/config/kontour.php
@@ -150,4 +150,17 @@ return [
     'menu_hidden_items' => [
         //'Roles'
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Time format
+    |--------------------------------------------------------------------------
+    |
+    | The default time format is used for displaying non-relative times.
+    | Examlpe:
+    | D, M j, Y H:i T
+    | Mon, Mar 25, 2019 10:51 UTC
+    |
+     */
+    'time_format' => 'D, M j, Y H:i T',
 ];

--- a/resources/views/elements/time.blade.php
+++ b/resources/views/elements/time.blade.php
@@ -1,0 +1,1 @@
+<time datetime="{{ $carbon->toAtomString() }}">{{ $slot ?? !empty($format) ? $carbon->format($format) : $carbon->diffForHumans() }}</time>

--- a/resources/views/elements/time.blade.php
+++ b/resources/views/elements/time.blade.php
@@ -1,1 +1,1 @@
-<time datetime="{{ $carbon->toAtomString() }}">{{ $slot ?? !empty($format) ? $carbon->format($format) : $carbon->diffForHumans() }}</time>
+<time datetime="{{ $carbon->toAtomString() }}">{{ $slot ?? !empty($format) ? $carbon->format($format === true ? config('kontour.time_format') : $format) : $carbon->diffForHumans() }}</time>

--- a/resources/views/elements/time.blade.php
+++ b/resources/views/elements/time.blade.php
@@ -1,1 +1,1 @@
-<time datetime="{{ $carbon->toAtomString() }}">{{ $slot ?? !empty($format) ? $carbon->format($format === true ? config('kontour.time_format') : $format) : $carbon->diffForHumans() }}</time>
+<time datetime="{{ $carbon instanceof \Carbon\CarbonInterval ? $carbon->spec() : $carbon->toAtomString() }}">{{ $slot ?? !empty($format) ? $carbon->format($format === true ? config('kontour.time_format') : $format) : ($carbon instanceof \Carbon\CarbonInterval ? $carbon->forHumans() : $carbon->diffForHumans()) }}</time>

--- a/resources/views/widgets/itemHistory.blade.php
+++ b/resources/views/widgets/itemHistory.blade.php
@@ -4,7 +4,7 @@
   @foreach($entries as $entry)
     <li lang="en" data-kontour-entry-action="{{ $entry['action'] }}"@if($entry['user']) data-kontour-username="{{ $entry['user']->getDisplayName() }}"@endif>
         <span>{{ ucfirst($entry['action']) }}</span>
-        <time datetime="{{ $entry['datetime']->toAtomString() }}">{{ $entry['datetime']->diffForHumans() }}</time>
+        @include('kontour::elements.time', ['carbon' => $entry['datetime']])
         @if($entry['user'])
             <span>by</span> <span>{{ $entry['user']->getDisplayName() }}</span>
         @endif

--- a/tests/Feature/ElementViewTests/TimeTest.php
+++ b/tests/Feature/ElementViewTests/TimeTest.php
@@ -26,4 +26,14 @@ class TimeTest extends IntegrationTest
         $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
         $this->assertContains('>' . $carbon->format($format) . '</time>', $output);
     }
+
+    public function test_can_use_default_format_from_config()
+    {
+        $carbon = Carbon::now();
+        $format = true;
+        $output = View::make('kontour::elements.time', compact('carbon', 'format'))->render();
+
+        $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
+        $this->assertContains('>' . $carbon->format(config('kontour.time_format')) . '</time>', $output);
+    }
 }

--- a/tests/Feature/ElementViewTests/TimeTest.php
+++ b/tests/Feature/ElementViewTests/TimeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kontenta\Kontour\Tests\Feature\FormViewTests;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\View;
+use Kontenta\Kontour\Tests\IntegrationTest;
+
+class TimeTest extends IntegrationTest
+{
+    public function test_displays_relative_time_by_default()
+    {
+        $carbon = Carbon::now();
+        $output = View::make('kontour::elements.time', compact('carbon'))->render();
+
+        $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
+        $this->assertRegExp('/>\d seconds? ago<\/time>$/', $output);
+    }
+
+    public function test_can_format_time()
+    {
+        $carbon = Carbon::now();
+        $format = 'Y';
+        $output = View::make('kontour::elements.time', compact('carbon', 'format'))->render();
+
+        $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
+        $this->assertContains('>' . $carbon->format($format) . '</time>', $output);
+    }
+}

--- a/tests/Feature/ElementViewTests/TimeTest.php
+++ b/tests/Feature/ElementViewTests/TimeTest.php
@@ -3,6 +3,7 @@
 namespace Kontenta\Kontour\Tests\Feature\FormViewTests;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterval;
 use Illuminate\Support\Facades\View;
 use Kontenta\Kontour\Tests\IntegrationTest;
 
@@ -35,5 +36,14 @@ class TimeTest extends IntegrationTest
 
         $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
         $this->assertContains('>' . $carbon->format(config('kontour.time_format')) . '</time>', $output);
+    }
+
+    public function test_can_display_time_interval()
+    {
+        $carbon = CarbonInterval::year();
+        $output = View::make('kontour::elements.time', compact('carbon'))->render();
+
+        $this->assertContains('datetime="' . $carbon->spec() . '"', $output);
+        $this->assertContains('>' . $carbon->forHumans() . '</time>', $output);
     }
 }


### PR DESCRIPTION
This PR adds a time tag template that can be used to print `<time>` elements with proper `datetime` attributes and a formatted time for humans.

This also adds a default `time_format` config value that can set the default format site-wide.
(This doesn't do anything about users' timezones... we'll have to consider that separately)

