### PR TITLE
Only use old data in forms when errors are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ This is actually a good pattern for scoping variables to one of the forms on you
 @include('my_form_partial', ['errors' => $errors->my_form_bag, 'model' => $user])
 ```
 
+If the `$errors` bag contains any errors,
+[old input data from the previous request](https://laravel.com/docs/5.8/helpers#method-old)
+will be used to repopulate the form.
+
 The `id` attribute is set automatically on created elements that need it,
 and it's usually derieved from the `$name` variable.
 If you get an id conflict on a page where two inputs may have the same name,

--- a/resources/views/forms/elements/checkbox.blade.php
+++ b/resources/views/forms/elements/checkbox.blade.php
@@ -1,5 +1,5 @@
 <input type="checkbox"
-  @if(old($name, $checked ?? $model[$name] ?? false))
+  @if(($errors->any() ? old($name) : null) ?? $checked ?? $model[$name] ?? false))
     checked
   @endif
   value="{{ $value ?? $checkboxDefaultValue ?? '1' }}"

--- a/resources/views/forms/elements/input.blade.php
+++ b/resources/views/forms/elements/input.blade.php
@@ -1,6 +1,6 @@
 <input type="{{ $type = $type ?? 'text' }}"
   @if($type != 'password')
-    value="{{ old($name, $value ?? $slot ?? $model[$name] ?? '') }}"
+    value="{{ ($errors->any() ? old($name) : null) ?? $value ?? $slot ?? $model[$name] ?? '' }}"
   @endif
   @include('kontour::forms.partials.inputAttributes')
 >

--- a/resources/views/forms/groups/checkboxes.blade.php
+++ b/resources/views/forms/groups/checkboxes.blade.php
@@ -1,5 +1,5 @@
 <fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
-  data-checked-checkboxes="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
+  data-checked-checkboxes="{{ implode(' ', $selected = collect(($errors->any() ? old($name) : null) ?? $selected ?? $model[$name] ?? [])->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
   @include('kontour::forms.partials.groupAttributes')
 >
   @include('kontour::forms.elements.label', [

--- a/resources/views/forms/groups/multiselect.blade.php
+++ b/resources/views/forms/groups/multiselect.blade.php
@@ -1,5 +1,5 @@
 <{{ $groupTag = $groupTag ?? 'div' }}
-  data-selected-options="{{ implode(' ', $selected = collect(old($name, $selected ?? $model[$name] ?? []))->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
+  data-selected-options="{{ implode(' ', $selected = collect(($errors->any() ? old($name) : null) ?? $selected ?? $model[$name] ?? [])->map(function($item) { return strval($item instanceof Illuminate\Database\Eloquent\Model ? $item->getKey() : $item); })->all()) }}"
   @include('kontour::forms.partials.groupAttributes')
 >
   <input type="hidden" name="{{ $name }}" value="">

--- a/resources/views/forms/groups/radiobuttons.blade.php
+++ b/resources/views/forms/groups/radiobuttons.blade.php
@@ -1,5 +1,5 @@
 <fieldset id="{{ $groupId = $controlId ?? (($idPrefix ?? '') . $name) }}"
-  data-checked-radio="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
+  data-checked-radio="{{ $selected = strval(($errors->any() ? old($name) : null) ?? $selected ?? $model[$name] ?? '') }}"
   @include('kontour::forms.partials.groupAttributes')
 >
   @include('kontour::forms.elements.label', [

--- a/resources/views/forms/groups/select.blade.php
+++ b/resources/views/forms/groups/select.blade.php
@@ -1,5 +1,5 @@
 <{{ $groupTag = $groupTag ?? 'div' }}
-  data-selected-option="{{ $selected = strval(old($name, $selected ?? $model[$name] ?? '')) }}"
+  data-selected-option="{{ $selected = strval(($errors->any() ? old($name) : null) ?? $selected ?? $model[$name] ?? '') }}"
   @include('kontour::forms.partials.groupAttributes')
 >
   @include('kontour::forms.label', [

--- a/resources/views/forms/groups/textarea.blade.php
+++ b/resources/views/forms/groups/textarea.blade.php
@@ -10,7 +10,7 @@
       @include('kontour::forms.partials.inputAttributes', [
         'errorsId' => $errorsId = $controlId . ($errorsSuffix ?? 'Errors'),
       ])
-    >{{ old($name, $value ?? $slot ?? $model[$name] ?? '') }}</textarea>
+    >{{ ($errors->any() ? old($name) : null) ?? $value ?? $slot ?? $model[$name] ?? '' }}</textarea>
     {{ $afterControl ?? '' }}
     @include('kontour::forms.partials.errors')
   </div>

--- a/tests/Feature/FormViewTests/CheckboxTest.php
+++ b/tests/Feature/FormViewTests/CheckboxTest.php
@@ -96,13 +96,25 @@ class CheckboxTest extends IntegrationTest
         $this->assertRegExp('/<input[\S\s]*value="3"[\S\s]*>/', $output);
     }
 
-    public function test_old_value_is_used_if_in_session()
+    public function test_old_value_is_not_used_if_no_errors()
     {
         $this->withSession(['_old_input' => ['test' => true]]);
         request()->setLaravelSession(session());
         $output = View::make('kontour::forms.checkbox', [
             'name' => 'test',
             'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertNotRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
+    }
+
+    public function test_old_value_is_used_if_in_session_with_errors()
+    {
+        $this->withSession(['_old_input' => ['test' => true]]);
+        request()->setLaravelSession(session());
+        $output = View::make('kontour::forms.checkbox', [
+            'name' => 'test',
+            'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
         $this->assertRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
@@ -131,7 +143,7 @@ class CheckboxTest extends IntegrationTest
                 $value = $value['test'];
             }
             $regexp = '/<input[\S\s]*checked[\S\s]*>/';
-            if($value) {
+            if ($value) {
                 $this->assertRegExp($regexp, $output);
             } else {
                 $this->assertNotRegExp($regexp, $output);

--- a/tests/Feature/FormViewTests/CheckboxesTest.php
+++ b/tests/Feature/FormViewTests/CheckboxesTest.php
@@ -102,7 +102,7 @@ class CheckboxesTest extends IntegrationTest
         $this->assertRegExp('/<fieldset[^>]*>[\S\s]*<input[^>]*value="a"[^>]*>A[\S\s]*<input[^>]*value="b"\s*checked[^>]*>B[\S\s]*<fieldset[^>]*>\s*<legend>A Group<\/legend>[\S\s]*<input[^>]*value="c"\s*checked[^>]*>C[\S\s]*<input[^>]*value="d"[^>]*>D[\S\s]*<\/fieldset>[\S\s]*<\/fieldset>/', $output);
     }
 
-    public function test_old_value_is_used_if_in_session()
+    public function test_old_value_is_not_used_if_no_errors()
     {
         $this->withSession(['_old_input' => ['test' => 'a']]);
         request()->setLaravelSession(session());
@@ -110,6 +110,19 @@ class CheckboxesTest extends IntegrationTest
             'name' => 'test',
             'options' => ['a' => 'A', 'b' => 'B'],
             'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertNotRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+    }
+
+    public function test_old_value_is_used_if_in_session_with_errors()
+    {
+        $this->withSession(['_old_input' => ['test' => 'a']]);
+        request()->setLaravelSession(session());
+        $output = View::make('kontour::forms.checkboxes', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
         $this->assertRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/InputTest.php
+++ b/tests/Feature/FormViewTests/InputTest.php
@@ -87,13 +87,25 @@ class InputTest extends IntegrationTest
         $this->assertRegExp('/<input[\S\s]*value=""[\S\s]*>/', $output);
     }
 
-    public function test_old_value_is_used_if_in_session()
+    public function test_old_value_is_not_used_if_no_errors()
     {
         $this->withSession(['_old_input' => ['test' => 'old']]);
         request()->setLaravelSession(session());
         $output = View::make('kontour::forms.input', [
             'name' => 'test',
             'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertNotRegExp('/<input[\S\s]*value="old"[\S\s]*>/', $output);
+    }
+
+    public function test_old_value_is_used_if_in_session_with_errors()
+    {
+        $this->withSession(['_old_input' => ['test' => 'old']]);
+        request()->setLaravelSession(session());
+        $output = View::make('kontour::forms.input', [
+            'name' => 'test',
+            'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
         $this->assertRegExp('/<input[\S\s]*value="old"[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/MultiselectTest.php
+++ b/tests/Feature/FormViewTests/MultiselectTest.php
@@ -117,7 +117,7 @@ class MultiselectTest extends IntegrationTest
         $this->assertRegExp('/<select[\S\s]*>\s*<option\s*value="a"\s*>A<\/option>\s*<option\s*value="b"\s*selected\s*>B<\/option>\s*<optgroup\s*label="A Group">\s*<option\s*value="c"\s*selected\s*>C<\/option>\s*<option\s*value="d"\s*>D<\/option>\s*<\/optgroup>\s*<\/select>/', $output);
     }
 
-    public function test_old_value_is_used_if_in_session()
+    public function test_old_value_is_not_used_if_no_errors()
     {
         $this->withSession(['_old_input' => ['test' => 'a']]);
         request()->setLaravelSession(session());
@@ -125,6 +125,19 @@ class MultiselectTest extends IntegrationTest
             'name' => 'test',
             'options' => ['a' => 'A', 'b' => 'B'],
             'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertNotRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+    }
+
+    public function test_old_value_is_used_if_in_session_with_errors()
+    {
+        $this->withSession(['_old_input' => ['test' => 'a']]);
+        request()->setLaravelSession(session());
+        $output = View::make('kontour::forms.multiselect', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
         $this->assertRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/RadiobuttonsTest.php
+++ b/tests/Feature/FormViewTests/RadiobuttonsTest.php
@@ -67,7 +67,7 @@ class RadiobuttonsTest extends IntegrationTest
         $this->assertRegExp('/<fieldset[^>]*>[\S\s]*<input[^>]*value="a"[^>]*>A[\S\s]*<input[^>]*value="b"[^>]*>B[\S\s]*<fieldset[^>]*>\s*<legend>A Group<\/legend>[\S\s]*<input[^>]*value="c"\s*checked[^>]*>C[\S\s]*<input[^>]*value="d"[^>]*>D[\S\s]*<\/fieldset>[\S\s]*<\/fieldset>/', $output);
     }
 
-    public function test_old_value_is_used_if_in_session()
+    public function test_old_value_is_not_used_if_no_errors()
     {
         $this->withSession(['_old_input' => ['test' => 'a']]);
         request()->setLaravelSession(session());
@@ -75,6 +75,19 @@ class RadiobuttonsTest extends IntegrationTest
             'name' => 'test',
             'options' => ['a' => 'A', 'b' => 'B'],
             'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertNotRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+    }
+
+    public function test_old_value_is_used_if_in_session_with_errors()
+    {
+        $this->withSession(['_old_input' => ['test' => 'a']]);
+        request()->setLaravelSession(session());
+        $output = View::make('kontour::forms.radiobuttons', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
         $this->assertRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -81,7 +81,7 @@ class SelectTest extends IntegrationTest
         $this->assertRegExp('/<select[\S\s]*>\s*<option\s*value="a"\s*>A<\/option>\s*<option\s*value="b"\s*>B<\/option>\s*<optgroup\s*label="A Group">\s*<option\s*value="c"\s*selected\s*>C<\/option>\s*<option\s*value="d"\s*>D<\/option>\s*<\/optgroup>\s*<\/select>/', $output);
     }
 
-    public function test_old_value_is_used_if_in_session()
+    public function test_old_value_is_not_used_if_no_errors()
     {
         $this->withSession(['_old_input' => ['test' => 'a']]);
         request()->setLaravelSession(session());
@@ -89,6 +89,19 @@ class SelectTest extends IntegrationTest
             'name' => 'test',
             'options' => ['a' => 'A', 'b' => 'B'],
             'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertNotRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+    }
+
+    public function test_old_value_is_used_if_in_session_with_errors()
+    {
+        $this->withSession(['_old_input' => ['test' => 'a']]);
+        request()->setLaravelSession(session());
+        $output = View::make('kontour::forms.select', [
+            'name' => 'test',
+            'options' => ['a' => 'A', 'b' => 'B'],
+            'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
         $this->assertRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);

--- a/tests/Feature/FormViewTests/TextareaTest.php
+++ b/tests/Feature/FormViewTests/TextareaTest.php
@@ -53,13 +53,25 @@ class TextareaTest extends IntegrationTest
         $this->assertRegExp('/<textarea[\S\s]*><\/textarea>/', $output);
     }
 
-    public function test_old_value_is_used_if_in_session()
+    public function test_old_value_is_not_used_if_no_errors()
     {
         $this->withSession(['_old_input' => ['test' => 'old']]);
         request()->setLaravelSession(session());
         $output = View::make('kontour::forms.textarea', [
             'name' => 'test',
             'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertNotRegExp('/<textarea[\S\s]*>old<\/textarea>/', $output);
+    }
+
+    public function test_old_value_is_used_if_in_session_with_errors()
+    {
+        $this->withSession(['_old_input' => ['test' => 'old']]);
+        request()->setLaravelSession(session());
+        $output = View::make('kontour::forms.textarea', [
+            'name' => 'test',
+            'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
         $this->assertRegExp('/<textarea[\S\s]*>old<\/textarea>/', $output);


### PR DESCRIPTION
This PR updates the form input templates to only repopulate forms whenever there are errors present in the errors message bag.

For a first time page-load there is no difference as there are no errors and no old data anyway.

This makes it possible to have multiple forms on the same page without them repopulating each other.
Devs only need to pass different error bags into different forms.

Closes #114 