### PR TITLE
Support Laravel 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ phpunit.xml
 phpcs.xml
 /tests/Browser/console/
 /tests/Browser/screenshots/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: LARAVEL='5.7.*'
     - php: 7.3
       env: LARAVEL='5.8.*'
+    - php: 7.3
+      env: LARAVEL='6.*'
   fast_finish: true
 
 services:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,7 +45,8 @@ See `.travis.yml` for details.
 
 #### Chrome versions
 
-If tests report wrong Chrome versions, run `./vendor/bin/dusk-updater update`
+If tests report wrong Chrome versions, run
+`./vendor/bin/dusk-updater detect --auto-update`
 to set it right before running tests again.
 
 ## Following PSR2

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "require-dev": {
     "mockery/mockery": "^1.2",
-    "orchestra/testbench-dusk": "~3.7.1 || ^3.8.1",
+    "orchestra/testbench-dusk": "~3.7.2 || ~3.8.2 || ^4.0.1",
     "squizlabs/php_codesniffer": "^3.3",
     "timacdonald/log-fake": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Admin area tool utilities for Laravel",
   "license": "MIT",
   "require": {
-    "laravel/framework": "5.7.*|5.8.*"
+    "laravel/framework": "5.7.* || 5.8.* || ^6.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "mockery/mockery": "^1.2",
     "orchestra/testbench-dusk": "~3.7.2 || ~3.8.2 || ^4.0.1",
     "squizlabs/php_codesniffer": "^3.3",
-    "timacdonald/log-fake": "^1.0"
+    "timacdonald/log-fake": "^1.0",
+    "phpunit/phpunit": ">7.5"
   },
   "autoload": {
     "psr-4": {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 use Faker\Generator as Faker;
+use Illuminate\Support\Str;
 
 $factory->define(\Kontenta\Kontour\Tests\Feature\Fakes\User::class, function (Faker $faker) {
     static $password;
@@ -9,6 +10,6 @@ $factory->define(\Kontenta\Kontour\Tests\Feature\Fakes\User::class, function (Fa
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
         'password' => $password ?: $password = bcrypt('secret'),
-        'remember_token' => str_random(10),
+        'remember_token' => Str::random(10),
     ];
 });

--- a/resources/views/forms/elements/label.blade.php
+++ b/resources/views/forms/elements/label.blade.php
@@ -7,4 +7,4 @@
     @include('kontour::partials.attribute')
   @endforeach
 @endif
->{{ $labelStart ?? '' }}{{ $label ?? ucfirst(Lang::has('validation.attributes.'.$name) ? Lang::trans('validation.attributes.' . $name) : str_replace(['_', '.', '[]'], [' ', ' ', ''], $name)) }}{{ $labelEnd ?? '' }}</{{ $labelTag }}>
+>{{ $labelStart ?? '' }}{{ $label ?? ucfirst(Lang::has('validation.attributes.'.$name) ? Lang::get('validation.attributes.' . $name) : str_replace(['_', '.', '[]'], [' ', ' ', ''], $name)) }}{{ $labelEnd ?? '' }}</{{ $labelTag }}>

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Log;
 use Kontenta\Kontour\Tests\Feature\Fakes\User;
 use Kontenta\Kontour\Tests\IntegrationTest;
 use TiMacDonald\Log\LogFake;
+use Illuminate\Support\Str;
 
 class AuthenticationTest extends IntegrationTest
 {
@@ -76,9 +77,9 @@ class AuthenticationTest extends IntegrationTest
         $response->assertStatus(500);
         Log::assertLogged('error', function ($message, $context) {
             return (
-                str_contains($message, 'Kontenta\Kontour\Contracts\AdminUser') and
-                str_contains($message, 'Illuminate\Foundation\Auth\User') and
-                str_contains($message, "'admin'")
+                Str::contains($message, 'Kontenta\Kontour\Contracts\AdminUser') and
+                Str::contains($message, 'Illuminate\Foundation\Auth\User') and
+                Str::contains($message, "'admin'")
             );
         });
     }

--- a/tests/Feature/ElementViewTests/TimeTest.php
+++ b/tests/Feature/ElementViewTests/TimeTest.php
@@ -14,7 +14,7 @@ class TimeTest extends IntegrationTest
         $carbon = Carbon::now();
         $output = View::make('kontour::elements.time', compact('carbon'))->render();
 
-        $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
+        $this->assertStringContainsString('datetime="' . $carbon->toAtomString() . '"', $output);
         $this->assertRegExp('/>\d seconds? ago<\/time>$/', $output);
     }
 
@@ -24,8 +24,8 @@ class TimeTest extends IntegrationTest
         $format = 'Y';
         $output = View::make('kontour::elements.time', compact('carbon', 'format'))->render();
 
-        $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
-        $this->assertContains('>' . $carbon->format($format) . '</time>', $output);
+        $this->assertStringContainsString('datetime="' . $carbon->toAtomString() . '"', $output);
+        $this->assertStringContainsString('>' . $carbon->format($format) . '</time>', $output);
     }
 
     public function test_can_use_default_format_from_config()
@@ -34,8 +34,8 @@ class TimeTest extends IntegrationTest
         $format = true;
         $output = View::make('kontour::elements.time', compact('carbon', 'format'))->render();
 
-        $this->assertContains('datetime="' . $carbon->toAtomString() . '"', $output);
-        $this->assertContains('>' . $carbon->format(config('kontour.time_format')) . '</time>', $output);
+        $this->assertStringContainsString('datetime="' . $carbon->toAtomString() . '"', $output);
+        $this->assertStringContainsString('>' . $carbon->format(config('kontour.time_format')) . '</time>', $output);
     }
 
     public function test_can_display_time_interval()
@@ -43,7 +43,7 @@ class TimeTest extends IntegrationTest
         $carbon = CarbonInterval::year();
         $output = View::make('kontour::elements.time', compact('carbon'))->render();
 
-        $this->assertContains('datetime="' . $carbon->spec() . '"', $output);
-        $this->assertContains('>' . $carbon->forHumans() . '</time>', $output);
+        $this->assertStringContainsString('datetime="' . $carbon->spec() . '"', $output);
+        $this->assertStringContainsString('>' . $carbon->forHumans() . '</time>', $output);
     }
 }

--- a/tests/Feature/UserlandServiceProviderTest.php
+++ b/tests/Feature/UserlandServiceProviderTest.php
@@ -15,12 +15,12 @@ class UserlandServiceProviderTest extends UserlandAdminToolTest
 
     public function test_routes_contain_userland_prefix()
     {
-        $this->assertContains('/userland-tool', route('userland.index'));
+        $this->assertStringContainsString('/userland-tool', route('userland.index'));
     }
 
     public function test_routes_contain_admin_prefix()
     {
-        $this->assertContains('/' . config('kontour.url_prefix'), route('userland.index'));
+        $this->assertStringContainsString('/' . config('kontour.url_prefix'), route('userland.index'));
     }
 
     public function test_widget_manager_contains_widget()


### PR DESCRIPTION
This PR allows Kontour to be installed with Laravel 6.

To get there the deprecated Laravel string helpers and `Lang::trans` had to be replaced.

Tests and test-related dependencies have been updated to get rid of all warnings.