### PR TITLE
Drop support for Laravel 5.7 and PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ language: php
 
 matrix:
   include:
-    - php: 7.1
-      env: LARAVEL='5.7.*'
     - php: 7.2
-      env: LARAVEL='5.7.*'
-    - php: 7.3
-      env: LARAVEL='5.7.*'
+      env: LARAVEL='5.8.*'
     - php: 7.3
       env: LARAVEL='5.8.*'
+    - php: 7.2
+      env: LARAVEL='6.*'
     - php: 7.3
       env: LARAVEL='6.*'
   fast_finish: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,7 +34,7 @@ Any Laravel log messages generated during testing can be found in the
 ### Testing with different versions
 
 [Travis CI](https://travis-ci.org/kontenta/kontour) is set up to run tests
-against PHP `7.1`, `7.2` & `7.3` in combination with Laravel `5.7` & `5.8`.
+against PHP `7.2` & `7.3` in combination with Laravel `5.8` & `6.*`.
 See `.travis.yml` for details.
 
 - `composer update --prefer-lowest` can be used before running tests for testing backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ authentication, authorization, validation, views, etc.
 Kontour is there to provide enhancements and reusable elements for your admin
 area.
 
-You need at least **Laravel 5.7** and **PHP 7.1** to use this package.
+You need at least **Laravel 5.8** and **PHP 7.2** to use this package.
 
 ## Features
 

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,13 @@
   "description": "Admin area tool utilities for Laravel",
   "license": "MIT",
   "require": {
-    "laravel/framework": "5.7.* || 5.8.* || ^6.0"
+    "laravel/framework": "5.8.* || ^6.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.2",
-    "orchestra/testbench-dusk": "~3.7.2 || ~3.8.2 || ^4.0.1",
+    "orchestra/testbench-dusk": "~3.8.2 || ^4.0.1",
     "squizlabs/php_codesniffer": "^3.3",
-    "timacdonald/log-fake": "^1.0",
-    "phpunit/phpunit": ">7.5"
+    "timacdonald/log-fake": "^1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR drops support for Laravel 5.7 and with it PHP 7.1

The reason we had to do this is that Nexmo changed their packages in some weird way, see https://github.com/laravel/framework/issues/30257