### PR TITLE
Config for route registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ The most common situation is that you want a separate table and model for
 admin users, and a separate Laravel User Provider and Guard to go with that.
 
 1. Create an Eloquent model and table.
-   The simplest way is to make copies of Laravel's `app/User.php` model and the
-   `create_users_table` migration in `database\migrations` and modify them
-   to your needs.
+   The simplest way is to make copies of Laravel's original `app/User.php` model
+   and
+   `database/migrations/2014_10_12_000000_create_users_table.php` migration
+   and modify them to your needs.
 2. Make sure the model implements `Kontenta\Kontour\Contracts\AdminUser`,
    perhaps by extending `Kontenta\Kontour\Auth\AdminUser`.
 3. Edit `config/auth.php` to add a Guard, User Provider and perhaps a password

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Installing Kontour explicitly in your Laravel project:
 composer require kontenta/kontour
 ```
 
+If you don't want the Kontour service provider to run in your project you may
+[opt out of package discovery](https://laravel.com/docs/packages#package-discovery).
+
 ## Checking the route list
 
 Kontour, and packages using it, will register routes automatically in your

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ in your app.
 Among others you'll find the `kontour.login`, `kontour.logout`,
 and `kontour.index` routes.
 If these routes are not to your liking there are configuration values you can
-set to change the url prefix or domain.
+set to change the url prefix or domain, or even turn them off completely.
 
 ## Configure Kontour in your Laravel project
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ The most common situation is that you want a separate table and model for
 admin users, and a separate Laravel User Provider and Guard to go with that.
 
 1. Create an Eloquent model and table.
-   The simplest way is to make copies of Laravel's `app/User.php` model and
-   create users table migration in `database\migrations` and modify them
+   The simplest way is to make copies of Laravel's `app/User.php` model and the
+   `create_users_table` migration in `database\migrations` and modify them
    to your needs.
 2. Make sure the model implements `Kontenta\Kontour\Contracts\AdminUser`,
    perhaps by extending `Kontenta\Kontour\Auth\AdminUser`.

--- a/config/kontour.php
+++ b/config/kontour.php
@@ -10,7 +10,7 @@ return [
     | The Kontour service provider registers admin auth and dashboard routes
     | unless turned off here.
     |
-     */
+    */
 
     'register_routes' => true,
 
@@ -21,7 +21,7 @@ return [
     |
     | Display name for header and page title of admin pages
     |
-     */
+    */
 
     'title' => 'Kontour ' . env('APP_NAME') . ' ' . env('APP_ENV'),
 
@@ -35,7 +35,7 @@ return [
     | If you've added a configuration for a separate Guard for admin pages in
     | your app's config/auth.php you should set that guard's name here.
     |
-     */
+    */
 
     'guard' => 'web',
 
@@ -50,7 +50,7 @@ return [
     | the configuration to 'passwords' in your app's config/auth.php and set
     | the configuration name here.
     |
-     */
+    */
 
     //'passwords' => 'users',
 
@@ -61,7 +61,7 @@ return [
     |
     | Common prefix for the admin urls.
     |
-     */
+    */
 
     'url_prefix' => 'admin',
 
@@ -75,7 +75,7 @@ return [
     | Set a domain name here if your admin pages should reside on another
     | domain or sub-domain than the rest of your app.
     |
-     */
+    */
 
     'domain' => null,
 
@@ -87,7 +87,7 @@ return [
     | Stylesheets & javascripts that load on all admin pages.
     | Can be full or relative urls.
     |
-     */
+    */
 
     'stylesheets' => [
         //'css/kontour.css',
@@ -103,7 +103,7 @@ return [
     |
     | Configure the widgets to load on all admin-pages.
     |
-     */
+    */
 
     'global_widgets' => [
         \Kontenta\Kontour\Contracts\MenuWidget::class => 'kontourNav',
@@ -119,7 +119,7 @@ return [
     |
     | Number of links to show in recent visits widgets.
     |
-     */
+    */
 
     'max_recent_visits' => [
         'personal' => 7,
@@ -133,7 +133,7 @@ return [
     |
     | Restructure the menu, overriding menu item positions.
     |
-     */
+    */
 
     // Move all links from one heading to another
     'menu_heading_names' => [
@@ -172,6 +172,6 @@ return [
     | D, M j, Y H:i T
     | Mon, Mar 25, 2019 10:51 UTC
     |
-     */
+    */
     'time_format' => 'D, M j, Y H:i T',
 ];

--- a/config/kontour.php
+++ b/config/kontour.php
@@ -72,7 +72,7 @@ return [
     | Stylesheets & javascripts
     |--------------------------------------------------------------------------
     |
-    | Stylesheets & javascripts to load on all admin pages.
+    | Stylesheets & javascripts that load on all admin pages.
     | Can be full or relative urls.
     |
      */

--- a/config/kontour.php
+++ b/config/kontour.php
@@ -156,7 +156,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | The default time format is used for displaying non-relative times.
-    | Examlpe:
+    | Example:
     | D, M j, Y H:i T
     | Mon, Mar 25, 2019 10:51 UTC
     |

--- a/config/kontour.php
+++ b/config/kontour.php
@@ -4,6 +4,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Route registration
+    |--------------------------------------------------------------------------
+    |
+    | The Kontour service provider registers admin auth and dashboard routes
+    | unless turned off here.
+    |
+     */
+
+    'register_routes' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Admin Title
     |--------------------------------------------------------------------------
     |
@@ -123,7 +135,7 @@ return [
     |
      */
 
-     // Move all links from one heading to another
+    // Move all links from one heading to another
     'menu_heading_names' => [
         //'Design' => 'Style', //Any links put in heading 'Design' will end up under heading 'Style'
     ],

--- a/src/Providers/KontourServiceProvider.php
+++ b/src/Providers/KontourServiceProvider.php
@@ -144,10 +144,15 @@ class KontourServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerResources();
-        $this->registerRoutes();
+
+        if (config('kontour.register_routes')) {
+            $this->registerRoutes();
+        }
+
         $this->registerEventListeners();
 
         $this->registerWidgets();
+
         $this->registerAssets();
 
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
This PR adds a `register_routes` config value so that consumers of Kontour may let the service provider run, but opt out of registration of the default auth and dashboard routes.

This is useful if you just want to use some part of Kontour, for example the form view templates.

Closes #124 