### PR TITLE
Set autocapitalize & autocorrect on email inputs

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,19 +8,27 @@
 ?>
 
 @section('kontourMain')
-  <header>{{ __('Login') }}</header>
-  <form method="POST" action="{{ route('kontour.login') }}">
-    @csrf
-    @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => ['required', 'autocomplete' => 'email']])
-    @include('kontour::forms.input', ['name' => 'password', 'type' => 'password', 'controlAttributes' => ['required', 'autocomplete' => 'current-password']])
-    @include('kontour::forms.checkbox', ['name' => 'remember', 'label' => __('Remember Me')])
-    @component('kontour::buttons.generic')
-      {{ __('Login') }}
-    @endcomponent
-    @if($route_manager->passwordResetUrl())
-      <a href="{{ $route_manager->passwordResetUrl() }}">
-        {{ __('Forgot Your Password?') }}
-      </a>
-    @endif
-  </form>
+<header>{{ __('Login') }}</header>
+<form method="POST" action="{{ route('kontour.login') }}">
+  @csrf
+  @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => [
+  'required',
+  'autocomplete' => 'email',
+  'autocapitalize' => 'none',
+  'autocorrect'=>'off',
+  ]])
+  @include('kontour::forms.input', ['name' => 'password', 'type' => 'password', 'controlAttributes' => [
+  'required',
+  'autocomplete' => 'current-password'
+  ]])
+  @include('kontour::forms.checkbox', ['name' => 'remember', 'label' => __('Remember Me')])
+  @component('kontour::buttons.generic')
+  {{ __('Login') }}
+  @endcomponent
+  @if($route_manager->passwordResetUrl())
+  <a href="{{ $route_manager->passwordResetUrl() }}">
+    {{ __('Forgot Your Password?') }}
+  </a>
+  @endif
+</form>
 @endsection

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -7,15 +7,20 @@
 ?>
 
 @section('kontourMain')
-  <header>{{ __('Reset Password') }}</header>
+<header>{{ __('Reset Password') }}</header>
 
-  {{ $messageWidget }}
+{{ $messageWidget }}
 
-  <form method="POST" action="{{ route('kontour.password.email') }}">
-    @csrf
-    @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => ['required', 'autocomplete' => 'email']])
-    @component('kontour::buttons.generic')
-      {{ __('Send Password Reset Link') }}
-    @endcomponent
-  </form>
+<form method="POST" action="{{ route('kontour.password.email') }}">
+  @csrf
+  @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => [
+  'required',
+  'autocomplete' => 'email',
+  'autocapitalize' => 'none',
+  'autocorrect'=>'off',
+  ]])
+  @component('kontour::buttons.generic')
+  {{ __('Send Password Reset Link') }}
+  @endcomponent
+</form>
 @endsection

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -7,15 +7,26 @@
 ?>
 
 @section('kontourMain')
-  <header>{{ __('Reset Password') }}</header>
-  <form method="POST" action="{{ route('kontour.password.request') }}">
-    @csrf
-    <input type="hidden" name="token" value="{{ $token }}">
-    @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => ['required', 'autocomplete' => 'email']])
-    @include('kontour::forms.input', ['name' => 'password', 'type' => 'password', 'controlAttributes' => ['required', 'autocomplete' => 'new-password']])
-    @include('kontour::forms.input', ['name' => 'password_confirmation', 'type' => 'password', 'controlAttributes' => ['required', 'autocomplete' => 'new-password']])
-    @component('kontour::buttons.generic')
-      {{ __('Reset Password') }}
-    @endcomponent
-  </form>
+<header>{{ __('Reset Password') }}</header>
+<form method="POST" action="{{ route('kontour.password.request') }}">
+  @csrf
+  <input type="hidden" name="token" value="{{ $token }}">
+  @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => [
+  'required',
+  'autocomplete' => 'email',
+  'autocapitalize' => 'none',
+  'autocorrect'=>'off',
+  ]])
+  @include('kontour::forms.input', ['name' => 'password', 'type' => 'password', 'controlAttributes' => [
+  'required',
+  'autocomplete' => 'new-password'
+  ]])
+  @include('kontour::forms.input', ['name' => 'password_confirmation', 'type' => 'password', 'controlAttributes' => [
+  'required',
+  'autocomplete' => 'new-password'
+  ]])
+  @component('kontour::buttons.generic')
+  {{ __('Reset Password') }}
+  @endcomponent
+</form>
 @endsection


### PR DESCRIPTION
Some browsers mess up email addresses unless auto-formatting is explicitly turned off.

Closes #137