### PR TITLE
Create email input

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -11,7 +11,7 @@
   <header>{{ __('Login') }}</header>
   <form method="POST" action="{{ route('kontour.login') }}">
     @csrf
-    @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => ['required', 'autocomplete' => 'email']])
+    @include('kontour::forms.email', ['controlAttributes' => ['required']])
     @include('kontour::forms.input', ['name' => 'password', 'type' => 'password', 'controlAttributes' => ['required', 'autocomplete' => 'current-password']])
     @include('kontour::forms.checkbox', ['name' => 'remember', 'label' => __('Remember Me')])
     @component('kontour::buttons.generic')

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -13,7 +13,7 @@
 
   <form method="POST" action="{{ route('kontour.password.email') }}">
     @csrf
-    @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => ['required', 'autocomplete' => 'email']])
+    @include('kontour::forms.email', ['controlAttributes' => ['required']])
     @component('kontour::buttons.generic')
       {{ __('Send Password Reset Link') }}
     @endcomponent

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -11,7 +11,7 @@
   <form method="POST" action="{{ route('kontour.password.request') }}">
     @csrf
     <input type="hidden" name="token" value="{{ $token }}">
-    @include('kontour::forms.input', ['name' => 'email', 'type' => 'email', 'controlAttributes' => ['required', 'autocomplete' => 'email']])
+    @include('kontour::forms.email', ['controlAttributes' => ['required']])
     @include('kontour::forms.input', ['name' => 'password', 'type' => 'password', 'controlAttributes' => ['required', 'autocomplete' => 'new-password']])
     @include('kontour::forms.input', ['name' => 'password_confirmation', 'type' => 'password', 'controlAttributes' => ['required', 'autocomplete' => 'new-password']])
     @component('kontour::buttons.generic')

--- a/resources/views/forms/email.blade.php
+++ b/resources/views/forms/email.blade.php
@@ -1,4 +1,5 @@
-@include('kontour::forms.input', [
-'type' => $type ?? 'email',
-'name' => $name ?? 'email',
-])
+@include('kontour::forms.input', ['type' => $type ?? 'email', 'name' => $name ?? 'email',
+'controlAttributes' => array_merge(
+['autocomplete' => 'email', 'autocapitalize' => 'none', 'autocorrect' => 'off'],
+$controlAttributes ?? []
+)])

--- a/resources/views/forms/email.blade.php
+++ b/resources/views/forms/email.blade.php
@@ -1,0 +1,4 @@
+@include('kontour::forms.input', [
+'type' => $type ?? 'email',
+'name' => $name ?? 'email',
+])

--- a/tests/Feature/FormViewTests/EmailTest.php
+++ b/tests/Feature/FormViewTests/EmailTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Kontenta\Kontour\Tests\Feature\FormViewTests;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\MessageBag;
+use Kontenta\Kontour\Tests\IntegrationTest;
+
+class EmailTest extends IntegrationTest
+{
+    public function test_input_type_defaults_to_email()
+    {
+        $output = View::make('kontour::forms.email', [
+            'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*type="email"[\S\s]*>/', $output);
+    }
+
+    public function test_input_type_can_be_specified()
+    {
+        $output = View::make('kontour::forms.email', [
+            'errors' => new MessageBag,
+            'type' => 'text',
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*type="text"[\S\s]*>/', $output);
+    }
+
+    public function test_input_name_defaults_to_email()
+    {
+        $output = View::make('kontour::forms.email', [
+            'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*name="email"[\S\s]*>/', $output);
+    }
+
+    public function test_input_name_can_be_specified()
+    {
+        $output = View::make('kontour::forms.email', [
+            'name' => 'test',
+            'errors' => new MessageBag,
+        ])->render();
+
+        $this->assertRegExp('/<input[\S\s]*name="test"[\S\s]*>/', $output);
+    }
+}

--- a/tests/Feature/FormViewTests/EmailTest.php
+++ b/tests/Feature/FormViewTests/EmailTest.php
@@ -10,8 +10,8 @@ class EmailTest extends IntegrationTest
 {
     public static $defaultEmailAttributes = [
         'autocomplete' => 'email',
-        'autocapitalize' => "none",
-        'autocorrect' => "off",
+        'autocapitalize' => 'none',
+        'autocorrect' => 'off',
     ];
 
     public function test_input_type_defaults_to_email()
@@ -60,6 +60,30 @@ class EmailTest extends IntegrationTest
 
         foreach (self::$defaultEmailAttributes as $attribute => $default) {
             $this->assertStringContainsString("$attribute=\"$default\"", $output);
+        }
+    }
+
+    public function test_control_attributes_can_be_set()
+    {
+        $output = View::make('kontour::forms.email', [
+            'errors' => new MessageBag,
+            'controlAttributes' => [
+                'autocomplete' => 'off',
+                'autocapitalize' => 'on',
+                'autocorrect' => 'on',
+                'required',
+                'a' => 'b',
+            ]
+        ])->render();
+
+        $this->assertRegExp('/\s+autocomplete="off"\W/', $output);
+        $this->assertRegExp('/\s+autocapitalize="on"\W/', $output);
+        $this->assertRegExp('/\s+autocorrect="on"\W/', $output);
+        $this->assertRegExp('/\s+required\W/', $output);
+        $this->assertRegExp('/\s+a="b"\W/', $output);
+
+        foreach (self::$defaultEmailAttributes as $attribute => $default) {
+            $this->assertStringNotContainsString("$attribute=\"$default\"", $output);
         }
     }
 }

--- a/tests/Feature/FormViewTests/EmailTest.php
+++ b/tests/Feature/FormViewTests/EmailTest.php
@@ -8,6 +8,12 @@ use Kontenta\Kontour\Tests\IntegrationTest;
 
 class EmailTest extends IntegrationTest
 {
+    public static $defaultEmailAttributes = [
+        'autocomplete' => 'email',
+        'autocapitalize' => "none",
+        'autocorrect' => "off",
+    ];
+
     public function test_input_type_defaults_to_email()
     {
         $output = View::make('kontour::forms.email', [
@@ -44,5 +50,16 @@ class EmailTest extends IntegrationTest
         ])->render();
 
         $this->assertRegExp('/<input[\S\s]*name="test"[\S\s]*>/', $output);
+    }
+
+    public function test_email_input_has_default_attributes()
+    {
+        $output = View::make('kontour::forms.email', [
+            'errors' => new MessageBag,
+        ])->render();
+
+        foreach (self::$defaultEmailAttributes as $attribute => $default) {
+            $this->assertStringContainsString("$attribute=\"$default\"", $output);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new form template for `email` type inputs. It's "extending" the normal input template, but it adds some sensible default attributes:

- `type="email"`
- `name="email"`
- `autocomplete="email"`
- `autocapitalize="none"`
- `autocorrect="off"` (for Safari)

Closes #137