### PR TITLE
Improve aria-describedby

### DIFF
--- a/docs/form-templates.md
+++ b/docs/form-templates.md
@@ -77,12 +77,12 @@ The `autofocusControlId` should be explicitly passed to each input when using
 ## Common parameters
 
 All inputs need at least the `$name` parameter
-and optional `$placeholder` and `$ariaDescribedById` parameters.
+and optional `$placeholder` parameters.
 
 All form views take a `$controlAttributes` `array` that can be used to set any
 additional HTML attributes on the form control element.
 This can be useful for setting
-`required`, `disabled`, `readonly`, `autocomplete`,
+`required`, `disabled`, `readonly`, `autocomplete`, `aria-describedby`,
 and other attributes specific to the
 [different input types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_<input>_types).
 

--- a/resources/views/forms/partials/inputAttributes.blade.php
+++ b/resources/views/forms/partials/inputAttributes.blade.php
@@ -1,20 +1,19 @@
 @include('kontour::forms.partials.nameAttribute')
 
-id="{{ $controlId }}"
-@if($errors->hasAny($errorsKeys ?? $name))
-aria-invalid="true"
 <?php
-  $controlAttributes['aria-describedby'] = array_merge([$errorsId], [$controlAttributes['aria-describedby'] ?? []])
+  $controlAttributes['id'] = $controlId;
+  unset($controlAttributes['name']);
+  if($errors->hasAny($errorsKeys ?? $name)) {
+    $controlAttributes['aria-invalid'] = "true";
+    $controlAttributes['aria-describedby'] = array_merge([$errorsId], [$controlAttributes['aria-describedby'] ?? []]);
+  }
+  if(!empty($autofocusControlId) and $autofocusControlId == $controlId) {
+    $controlAttributes[] = 'autofocus';
+  }
+  if(!empty($placeholder)) {
+    $controlAttributes['placeholder'] = $placeholder;
+  }
 ?>
-@endif
-@if(!empty($autofocusControlId) and $autofocusControlId == $controlId)
-autofocus
-@endif
-@if(!empty($placeholder))
-placeholder="{{ $placeholder }}"
-@endif
-@if(isset($controlAttributes) and is_iterable($controlAttributes))
 @foreach($controlAttributes as $attributeName => $attributeValue)
 @include('kontour::partials.attribute')
 @endforeach
-@endif

--- a/resources/views/forms/partials/inputAttributes.blade.php
+++ b/resources/views/forms/partials/inputAttributes.blade.php
@@ -7,7 +7,7 @@
     $controlAttributes['aria-invalid'] = "true";
     $controlAttributes['aria-describedby'] = array_merge([$errorsId], [$controlAttributes['aria-describedby'] ?? []]);
   }
-  if(!empty($autofocusControlId) and $autofocusControlId == $controlId) {
+  if(!empty($autofocusControlId) and $autofocusControlId == $controlId and !in_array('autofocus', $controlAttributes)) {
     $controlAttributes[] = 'autofocus';
   }
   if(!empty($placeholder)) {

--- a/resources/views/forms/partials/inputAttributes.blade.php
+++ b/resources/views/forms/partials/inputAttributes.blade.php
@@ -3,9 +3,9 @@
 id="{{ $controlId }}"
 @if($errors->hasAny($errorsKeys ?? $name))
 aria-invalid="true"
-aria-describedby="{{ $errorsId }}"
-@elseif(isset($ariaDescribedById))
-aria-describedby="{{ $ariaDescribedById }}"
+<?php
+  $controlAttributes['aria-describedby'] = array_merge([$errorsId], [$controlAttributes['aria-describedby'] ?? []])
+?>
 @endif
 @if(!empty($autofocusControlId) and $autofocusControlId == $controlId)
 autofocus

--- a/tests/Feature/FormViewTests/InputAttributesTest.php
+++ b/tests/Feature/FormViewTests/InputAttributesTest.php
@@ -93,24 +93,23 @@ class InputAttributesTest extends IntegrationTest
             'name' => 'testName',
             'controlId' => 'testId',
             'errors' => new MessageBag,
-            'ariaDescribedById' => 'descriptionId',
+            'controlAttributes' => ['aria-describedby' => 'descriptionId'],
         ])->render();
 
         $this->assertRegExp('/\s+aria-describedby="descriptionId"\W/', $output);
     }
 
-    public function test_error_input_overwriting_aria_describedby()
+    public function test_error_input_prepending_aria_describedby()
     {
         $output = View::make('kontour::forms.partials.inputAttributes', [
             'name' => 'testName',
             'controlId' => 'testId',
             'errors' => new MessageBag(['testName' => ['A message']]),
             'errorsId' => 'errorsId',
-            'ariaDescribedById' => 'descriptionId',
+            'controlAttributes' => ['aria-describedby' => 'descriptionId'],
         ])->render();
 
-        $this->assertRegExp('/\s+aria-describedby="errorsId"\W/', $output);
-        $this->assertNotRegExp('/aria-describedby="descriptionId"/', $output);
+        $this->assertRegExp('/\s+aria-describedby="errorsId\sdescriptionId"\W/', $output);
     }
 
     public function test_control_attributes()


### PR DESCRIPTION
This PR removes the dedicated `$ariaDescribedById` option for inputs and instead encourages use of `$controlAttributes['aria-describedby']`. This is ment to reduce the number of special options for inputs so that there are not conflicting ways of achieving the same thing.

After this, the only special parameters for inputs are `$name` and `$placeholder`... because they are treated differently in different inputs.

This also prepends any error description element id to `aria-describedby` instead of overwriting it so one can have multiple descriptive elements for an input.

Closes #152 