### PR TITLE
Keep list semantics for unstyled lists

### DIFF
--- a/resources/views/forms/partials/errors.blade.php
+++ b/resources/views/forms/partials/errors.blade.php
@@ -1,5 +1,5 @@
 @if($errors->hasAny($errorsKeys = $errorsKeys ?? $name))
-  <ul id="{{ $errorsId }}">
+  <ul id="{{ $errorsId }}" role="list">
     @foreach(\Illuminate\Support\Arr::wrap($errorsKeys) as $key)
       @foreach(\Illuminate\Support\Arr::flatten($errors->get($key)) as $message)
         <li>{{ $message }}</li>

--- a/resources/views/widgets/crumbtrail.blade.php
+++ b/resources/views/widgets/crumbtrail.blade.php
@@ -1,5 +1,5 @@
 <nav aria-label="{{ __('Crumb trail') }}" data-kontour-widget="crumbtrail">
-  <ol>
+  <ol role="list">
     @foreach($links as $link)
       <li{!! url()->full() == $link->getUrl() ? ' aria-current="true"' : '' !!}>{{ $link }}</li>
     @endforeach

--- a/resources/views/widgets/itemHistory.blade.php
+++ b/resources/views/widgets/itemHistory.blade.php
@@ -1,6 +1,6 @@
 <section data-kontour-widget="itemHistory">
   <header>{{ trans('kontour::widgets.itemHistory.title') }}</header>
-  <ul>
+  <ul role="list">
   @foreach($entries as $entry)
     <li lang="en" data-kontour-entry-action="{{ $entry['action'] }}"@if($entry['user']) data-kontour-username="{{ $entry['user']->getDisplayName() }}"@endif>
         <span>{{ ucfirst($entry['action']) }}</span>

--- a/resources/views/widgets/menu.blade.php
+++ b/resources/views/widgets/menu.blade.php
@@ -1,10 +1,10 @@
 @include('kontour::buttons.hamburger')
-<ul data-kontour-widget="menu">
+<ul data-kontour-widget="menu" role="list">
 @foreach($links as $heading => $headingLinks)
   @if(count($headingLinks))
     <li>
       <small>{{ $heading }}</small>
-      <ul>
+      <ul role="list">
       @foreach($headingLinks as $link)
         <li{!! preg_match('#'.$link->getUrl().'#', url()->full()) ? ' aria-current="true"' : '' !!}>{{ $link }}</li>
       @endforeach

--- a/resources/views/widgets/message.blade.php
+++ b/resources/views/widgets/message.blade.php
@@ -1,5 +1,5 @@
 <section data-kontour-widget="message">
-  <ol>
+  <ol role="list">
     @foreach($messages as $message)
       <li
         data-kontour-message-level="{{ $message['level'] }}"

--- a/resources/views/widgets/personalRecentVisits.blade.php
+++ b/resources/views/widgets/personalRecentVisits.blade.php
@@ -1,7 +1,7 @@
 @if(count($visits))
   <aside data-kontour-widget="personalRecentVisits">
     <header>{{ trans('kontour::widgets.personalRecentVisits.title') }}</header>
-    <ul>
+    <ul role="list">
     @foreach($visits as $visit)
       @if(url()->full() != $visit->getLink()->getUrl())
         <li data-kontour-visit-type="{{ $visit->getType() }}"{!! empty($visit->getLink()->getDescription()) ? ' title="' . e($visit->getLink()->getName()) . '"' : '' !!}>{{ $visit->getLink() }}</li>

--- a/resources/views/widgets/teamRecentVisits.blade.php
+++ b/resources/views/widgets/teamRecentVisits.blade.php
@@ -1,7 +1,7 @@
 @if(count($visits))
   <aside data-kontour-widget="teamRecentVisits">
     <header>{{ trans('kontour::widgets.teamRecentVisits.title') }}</header>
-    <ul>
+    <ul role="list">
     @foreach($visits as $visit)
       <li data-kontour-visit-type="{{ $visit->getType() }}" data-kontour-username="{{ $visit->getUser()->getDisplayName() }}"{!! empty($visit->getLink()->getDescription()) ? ' title="' . e($visit->getLink()->getName()) . '"' : '' !!}>{{ $visit->getLink() }}</li>
     @endforeach

--- a/tests/Feature/UserlandControllerTest.php
+++ b/tests/Feature/UserlandControllerTest.php
@@ -53,7 +53,7 @@ class UserlandControllerTest extends UserlandAdminToolTest
         $response = $this->actingAs($this->user, 'admin')->get(route('userland.index'));
 
         $response->assertSuccessful();
-        $response->assertSee('<ul data-kontour-widget="menu">', false);
+        $response->assertSee('<ul data-kontour-widget="menu" role="list">', false);
         $response->assertSee('>main<', false);
         $response->assertSee('<a href="' . route('userland.index') . '" aria-current="page">Userland Tool</a>', false);
         $response->assertSee('>External<', false);


### PR DESCRIPTION
This PR adds `role="list"` to all `<ul>` and `<ol>` elements to keep list-semantics in Safari.

See https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html#a-new-alternative

Closes #142