### PR TITLE
Display booleans and numbers nicely

### DIFF
--- a/resources/views/dashboard/laravelConfig.blade.php
+++ b/resources/views/dashboard/laravelConfig.blade.php
@@ -6,7 +6,17 @@
     @foreach(['app.name', 'app.url', 'app.env', 'app.debug', 'mail.from.address', 'mail.from.name', 'auth.defaults.guard', 'kontour.guard', 'session.cookie', 'session.lifetime', 'database.default', 'cache.default', 'filesystems.default'] as $configKey)
       <div>
         <dt><code>{{ $configKey }}</code></dt>
-        <dd>{{ config($configKey) }}</dd>
+        <dd>
+          @if(config($configKey) === true)
+            <code>true</code>
+          @elseif(config($configKey) === false)
+            <code>false</code>
+          @elseif(is_numeric(config($configKey)))
+            <code>{{ config($configKey) }}</code>
+          @else
+            {{ config($configKey) }}
+          @endif
+        </dd>
       </div>
     @endforeach
   </dl>


### PR DESCRIPTION
The kontour index page displays app config values and this PR makes those print in monospace font when booleans or numbers.

Closes #156