### PR TITLE
Start replacing regex assertions in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  beStrictAboutTestsThatDoNotTestAnything="false"
+  bootstrap="vendor/autoload.php"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="Package Tests">
       <directory suffix="Test.php">./tests</directory>
@@ -20,11 +29,6 @@
       <directory suffix="Test.php">./tests/Browser</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">./src</directory>
-    </whitelist>
-  </filter>
   <php>
     <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
     <env name="APP_URL" value="http://127.0.0.1:8000"/>

--- a/tests/Feature/FormViewTests/MultiselectTest.php
+++ b/tests/Feature/FormViewTests/MultiselectTest.php
@@ -137,7 +137,7 @@ class MultiselectTest extends IntegrationTest
             'selected' => ['c', 'b'],
         ])->render();
 
-        $this->assertEquals(2, preg_match_all('/\sselected\s/', $output,), 'Not exactly two selected options');
+        $this->assertEquals(2, preg_match_all('/\sselected\s/', $output), 'Not exactly two selected options');
 
         $tags = $this->splitHtmlTags($output);
         $this->assertStringContainsString('<select', $tags[4], 'Select tag is not in expected order');

--- a/tests/Feature/FormViewTests/MultiselectTest.php
+++ b/tests/Feature/FormViewTests/MultiselectTest.php
@@ -137,7 +137,26 @@ class MultiselectTest extends IntegrationTest
             'selected' => ['c', 'b'],
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*>\s*<option\s*value="a"\s*>A<\/option>\s*<option\s*value="b"\s*selected\s*>B<\/option>\s*<optgroup\s*label="A Group">\s*<option\s*value="c"\s*selected\s*>C<\/option>\s*<option\s*value="d"\s*>D<\/option>\s*<\/optgroup>\s*<\/select>/', $output);
+        $this->assertEquals(2, preg_match_all('/\sselected\s/', $output,), 'Not exactly two selected options');
+
+        $tags = $this->splitHtmlTags($output);
+        $this->assertStringContainsString('<select', $tags[4], 'Select tag is not in expected order');
+
+        $optionB = $tags[6];
+        $this->assertStringContainsString('value="b"', $optionB);
+        $this->assertStringContainsString('selected', $optionB);
+
+        $optgroup = $tags[7];
+        $this->assertStringContainsString('<optgroup', $optgroup, 'Optgroup tag is not in expected order');
+        $this->assertStringContainsString('label="A Group"', $optgroup);
+
+        $optionC = $tags[8];
+        $this->assertStringContainsString('value="c"', $optionC);
+        $this->assertStringContainsString('selected', $optionC);
+        $this->assertStringContainsString('>C<', $optionC);
+
+        $optionD = $tags[9];
+        $this->assertStringContainsString('value="d"', $optionD);
     }
 
     public function test_old_value_is_not_used_if_no_errors()
@@ -174,7 +193,8 @@ class MultiselectTest extends IntegrationTest
         ];
 
         while (count($fallbacks)) {
-            $output = View::make('kontour::forms.multiselect',
+            $output = View::make(
+                'kontour::forms.multiselect',
                 array_merge(
                     [
                         'name' => 'test',

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -115,7 +115,8 @@ class SelectTest extends IntegrationTest
         ];
 
         while (count($fallbacks)) {
-            $output = View::make('kontour::forms.select',
+            $output = View::make(
+                'kontour::forms.select',
                 array_merge(
                     [
                         'name' => 'test',
@@ -180,7 +181,12 @@ class SelectTest extends IntegrationTest
             'placeholder' => 'Select one',
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*>\s*<option[\S\s]*value=""[\S\s]*>Select one<\/option>/', $output);
+        $tags = preg_split('/(?<=>)\s*(?=<)/', $output);
+        $this->assertStringContainsString('<select', $tags[3], 'Select tag is not in expected order');
+
+        $firstOption = $tags[4];
+        $this->assertStringContainsString('Select one', $firstOption, "Placeholder is not first option in select");
+        $this->assertStringContainsString('value=""', $firstOption, "Placeholder value is not empty");
     }
 
     public function test_placeholder_does_not_replace_existing_blank_option()

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -78,7 +78,7 @@ class SelectTest extends IntegrationTest
             'selected' => 'c',
         ])->render();
 
-        $this->assertEquals(1, preg_match_all('/\sselected\s/', $output,), 'Not exactly one selected option');
+        $this->assertEquals(1, preg_match_all('/\sselected\s/', $output), 'Not exactly one selected option');
 
         $tags = $this->splitHtmlTags($output);
         $this->assertStringContainsString('<select', $tags[3], 'Select tag is not in expected order');

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -181,7 +181,7 @@ class SelectTest extends IntegrationTest
             'placeholder' => 'Select one',
         ])->render();
 
-        $tags = preg_split('/(?<=>)\s*(?=<)/', $output);
+        $tags = $this->splitHtmlTags($output);
         $this->assertStringContainsString('<select', $tags[3], 'Select tag is not in expected order');
 
         $firstOption = $tags[4];

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -78,7 +78,22 @@ class SelectTest extends IntegrationTest
             'selected' => 'c',
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*>\s*<option\s*value="a"\s*>A<\/option>\s*<option\s*value="b"\s*>B<\/option>\s*<optgroup\s*label="A Group">\s*<option\s*value="c"\s*selected\s*>C<\/option>\s*<option\s*value="d"\s*>D<\/option>\s*<\/optgroup>\s*<\/select>/', $output);
+        $this->assertEquals(1, preg_match_all('/\sselected\s/', $output,), 'Not exactly one selected option');
+
+        $tags = $this->splitHtmlTags($output);
+        $this->assertStringContainsString('<select', $tags[3], 'Select tag is not in expected order');
+
+        $optgroup = $tags[6];
+        $this->assertStringContainsString('<optgroup', $optgroup, 'Optgroup tag is not in expected order');
+        $this->assertStringContainsString('label="A Group"', $optgroup);
+
+        $optionC = $tags[7];
+        $this->assertStringContainsString('value="c"', $optionC);
+        $this->assertStringContainsString('selected', $optionC);
+        $this->assertStringContainsString('>C<', $optionC);
+
+        $optionD = $tags[8];
+        $this->assertStringContainsString('value="d"', $optionD);
     }
 
     public function test_old_value_is_not_used_if_no_errors()

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -14,4 +14,17 @@ abstract class IntegrationTest extends TestCase
         parent::setUp();
         Cache::flush();
     }
+
+    /**
+     * Split a string of HTML.
+     *
+     * Note: It doesn't split on complete tags, just when two consecutive tags
+     * have no other content between them.
+     * So always assert that you're asserting on the intended array item :)
+     */
+    protected function splitHtmlTags(string $html): array
+    {
+        // Split between `><` also allowing any number of spaces
+        return preg_split('/(?<=>)\s*(?=<)/', $html);
+    }
 }


### PR DESCRIPTION
`assertRegExp()` and `assertNotRegExp()` are deprecated and will be removed in PHPUnit 10.

We're using them quite a lot in our tests (more than a 100 times) and although it can be refactored to `assertMatchesRegularExpression()` it's better to try not using them at all. The tests become very hard to read when all it does is matching a massive regex.

So I've created a method that splits a string between `>` and `<` so we get an array of tags. Then more precise assertions can be made on those tags, instead of having them all in one big regex.

This PR contains updates to three tests (that were especially brittle), now using the new split instead of regex.

So this is just a start of a much bigger refactor, with the end goal of replacing the other 129 occurrences of regexp assertions with clearer tests! 😬 

Also, the xml format for phpunit config has changed, so this PR updates that as well.