### PR TITLE
Add two-word verbs for actions

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,14 +8,14 @@
 ?>
 
 @section('kontourMain')
-  <header>{{ __('Login') }}</header>
+  <header>{{ __('Log in') }}</header>
   <form method="POST" action="{{ route('kontour.login') }}">
     @csrf
     @include('kontour::forms.email', ['controlAttributes' => ['required']])
     @include('kontour::forms.input', ['name' => 'password', 'type' => 'password', 'controlAttributes' => ['required', 'autocomplete' => 'current-password']])
     @include('kontour::forms.checkbox', ['name' => 'remember', 'label' => __('Remember Me')])
     @component('kontour::buttons.generic')
-      {{ __('Login') }}
+      {{ __('Log in') }}
     @endcomponent
     @if($route_manager->passwordResetUrl())
       <a href="{{ $route_manager->passwordResetUrl() }}">

--- a/resources/views/buttons/hamburger.blade.php
+++ b/resources/views/buttons/hamburger.blade.php
@@ -6,5 +6,5 @@
     <rect class="middle" height="2" width="8" y="4" x="1"/>
     <rect class="bottom" height="2" width="8" y="7" x="1"/>
   </svg>
-  <span class="sr-only">{{ __('Menu') }}</span>
+  <span class="sr-only">{{ __('Open menu') }}</span>
 </button>

--- a/resources/views/buttons/logout.blade.php
+++ b/resources/views/buttons/logout.blade.php
@@ -5,5 +5,5 @@
     <polygon points="1,1 1,9 6,9 6,7 5,7 5,8 2,8 2,2 5,2 5,3, 6,3 6,1" />
     <polygon points="3,4 7,4 7,2 9,5 7,8 7,6 3,6" />
   </svg>
-  <span class="sr-only">{{ __('Logout') }}</span>
+  <span class="sr-only">{{ __('Log out') }}</span>
 </button>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -8,7 +8,7 @@
 
   <header data-kontour-section="kontourHeader">
     @section('kontourHeader')
-      {{ \Kontenta\Kontour\AdminLink::create(config('kontour.title'), route('kontour.index'), __('Dashboard')) }}
+      {{ \Kontenta\Kontour\AdminLink::create(config('kontour.title'), route('kontour.index'), __('View dashboard')) }}
       @foreach($widget_manager->getWidgetsForSection('kontourHeader') as $widget)
         {{ $widget }}
       @endforeach

--- a/tests/Browser/AuthenticationTest.php
+++ b/tests/Browser/AuthenticationTest.php
@@ -23,7 +23,7 @@ class AuthenticationTest extends DuskTest
                 ->type('password', 'secret')
                 ->resize(500, 500)
                 ->screenshot('docs/login')
-                ->press('Login')
+                ->press('Log in')
                 ->assertUrlIs($routeManager->indexUrl());
         });
     }
@@ -40,7 +40,7 @@ class AuthenticationTest extends DuskTest
              */
             $routeManager = $this->app->make(\Kontenta\Kontour\Contracts\AdminRouteManager::class);
             $browser->loginAs($this->user, 'admin')->visit($routeManager->indexUrl())
-                ->press('Logout')
+                ->press('Log out')
                 ->assertUrlIs($routeManager->loginUrl());
         });
     }

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -101,7 +101,7 @@ class AuthenticationTest extends IntegrationTest
         $response = $this->actingAs($this->user, 'admin')->get($routeManager->indexUrl());
         $response->assertSee('<section data-kontour-widget="userAccount">', false);
         $response->assertSee($this->user->getDisplayName());
-        $response->assertSee(">Logout</span>\n</button>", false);
+        $response->assertSee(">Log out</span>\n</button>", false);
     }
 
     public function test_logout()


### PR DESCRIPTION
This is to avoid conflicts with userland translation files with single-word names.
See https://github.com/kontenta/kontour/issues/178

Closes #191