### PR TITLE
Support Laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       env: LARAVEL='7.*'
     - php: 7.4
       env: LARAVEL='7.*'
+    - php: 7.3
+      env: LARAVEL='8.*'
+    - php: 7.4
+      env: LARAVEL='8.*'
   fast_finish: true
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,8 @@ language: php
 
 matrix:
   include:
-    - php: 7.2
-      env: LARAVEL='5.8.*'
     - php: 7.3
       env: LARAVEL='5.8.*'
-    - php: 7.2
-      env: LARAVEL='6.*'
     - php: 7.3
       env: LARAVEL='6.*'
     - php: 7.3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,7 +34,7 @@ Any Laravel log messages generated during testing can be found in the
 ### Testing with different versions
 
 [Travis CI](https://travis-ci.org/kontenta/kontour) is set up to run tests against
-PHP `7.2`, `7.3` & `7.4` in combination with
+PHP `7.3` & `7.4` in combination with
 Laravel `5.8`, `6`, `7` & `8`.
 See `.travis.yml` for details.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,8 +33,9 @@ Any Laravel log messages generated during testing can be found in the
 
 ### Testing with different versions
 
-[Travis CI](https://travis-ci.org/kontenta/kontour) is set up to run tests
-against PHP `7.2` & `7.3` in combination with Laravel `5.8` & `6.*`.
+[Travis CI](https://travis-ci.org/kontenta/kontour) is set up to run tests against
+PHP `7.2`, `7.3` & `7.4` in combination with
+Laravel `5.8`, `6`, `7` & `8`.
 See `.travis.yml` for details.
 
 - `composer update --prefer-lowest` can be used before running tests for testing backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ authentication, authorization, validation, views, etc.
 Kontour is there to provide enhancements and reusable elements for your admin
 area.
 
-You need at least **Laravel 5.8** and **PHP 7.2** to use this package.
+You need at least **Laravel 5.8** and **PHP 7.3** to use this package.
 
 ## Using Kontour in a Laravel app
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.3",
     "laravel/framework": "5.8.* || ^6.0 || ^7.0 || ^8.0",
-    "laravel/ui": "^1.0 || ^2.0"
+    "laravel/ui": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "laravel/legacy-factories": "^1.0.4",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "Admin area tool utilities for Laravel",
   "license": "MIT",
   "require": {
+    "php": ">=7.3",
     "laravel/framework": "5.8.* || ^6.0 || ^7.0 || ^8.0",
     "laravel/ui": "^1.0 || ^2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,13 @@
   "description": "Admin area tool utilities for Laravel",
   "license": "MIT",
   "require": {
-    "laravel/framework": "5.8.* || ^6.0 || ^7.0",
+    "laravel/framework": "5.8.* || ^6.0 || ^7.0 || ^8.0",
     "laravel/ui": "^1.0 || ^2.0"
   },
   "require-dev": {
+    "laravel/legacy-factories": "^1.0.4",
     "mockery/mockery": "^1.2",
-    "orchestra/testbench-dusk": "3.8.2 || ^4.0.1 || ^5.0",
+    "orchestra/testbench-dusk": "3.8.2 || ^4.0.1 || ^5.0 || ^6.0",
     "squizlabs/php_codesniffer": "^3.3",
     "timacdonald/log-fake": "^1.0"
   },


### PR DESCRIPTION
Add support for Laravel 8.

We need to drop support for PHP `7.2` for the next version of Kontour because the tests are using `laravel/legacy-factories` that only support PHP `7.3`.

See #190 