### PR TITLE
Replace underscores in html lang attributes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,6 @@
   </testsuites>
   <php>
     <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-    <env name="APP_URL" value="http://127.0.0.1:8000"/>
+    <env name="APP_URL" value="http://127.0.0.1:8001"/>
   </php>
 </phpunit>

--- a/resources/views/layouts/html.blade.php
+++ b/resources/views/layouts/html.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/tests/DuskTest.php
+++ b/tests/DuskTest.php
@@ -12,6 +12,8 @@ abstract class DuskTest extends TestCase
         getEnvironmentSetUp as traitGetEnvironmentSetup;
     }
 
+    protected static $baseServePort = 8001;
+
     /**
      * @var User
      */


### PR DESCRIPTION
This PR makes the language code correct if the app locale has an underscore, it's replaced with a dash. See [BCP47 at MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang).

Example: `en_US` becomes `en-US` in the hTML attribute.

Fixes #195