### PR TITLE
Support Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1]
+        php: [8.2, 8.1, 8.0]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,10 @@
 name: Run tests
-on: push
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: Run tests
 on: push
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
+        os: [ubuntu-latest]
         php: [8.2, 8.1]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,8 +16,6 @@ jobs:
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,6 @@ jobs:
         include:
           - laravel: 9.*
             testbench: 7.*
-            carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -35,7 +34,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List installed Composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,17 +9,37 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.1]
+        laravel: [9.*]
+        stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 9.*
+            testbench: 7.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install -n --prefer-dist
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: List installed Composer dependencies
+        run: composer show -D
 
       - name: Run feature tests
         run: composer test -- --testsuite=Feature

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,7 @@ jobs:
         include:
           - laravel: 9.*
             testbench: 7.*
+            carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -33,7 +34,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List installed Composer dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,6 @@ jobs:
         run: composer test -- --testsuite=Feature
 
       - name: Run Dusk tests
-        run: composer test -- --testsuite=Dusk
+        run: |
+          ./vendor/bin/dusk-updater detect --auto-update
+          composer test -- --testsuite=Dusk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,6 @@ jobs:
 
       - name: Run feature tests
         run: composer test -- --testsuite=Feature
+
+      - name: Run Dusk tests
+        run: composer test -- --testsuite=Dusk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Run tests
+on: push
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install -n --prefer-dist
+
+      - name: Run feature tests
+        run: composer test -- --testsuite=Feature

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ authentication, authorization, validation, views, etc.
 Kontour is there to provide enhancements and reusable elements for your admin
 area.
 
-You need at least **Laravel 5.8** and **PHP 7.3** to use this package.
+You need at least **Laravel 8** to use the latest version of this package.
 
 ## Using Kontour in a Laravel app
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ authentication, authorization, validation, views, etc.
 Kontour is there to provide enhancements and reusable elements for your admin
 area.
 
-You need at least **Laravel 8** to use the latest version of this package.
+You need **Laravel 9** to use the latest version of this package.
 
 ## Using Kontour in a Laravel app
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "Admin area tool utilities for Laravel",
   "license": "MIT",
   "require": {
-    "php": ">=8.0",
     "laravel/framework": "^9.0",
     "laravel/ui": "^4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
   "license": "MIT",
   "require": {
     "php": ">=7.3",
-    "laravel/framework": "5.8.* || ^6.0 || ^7.0 || ^8.0",
-    "laravel/ui": "^1.0 || ^2.0 || ^3.0"
+    "laravel/framework": "5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+    "laravel/ui": "^1.0 || ^2.0 || ^3.0 || ^4.0"
   },
   "require-dev": {
     "laravel/legacy-factories": "^1.0.4",
     "mockery/mockery": "^1.2",
-    "orchestra/testbench-dusk": "3.8.2 || ^4.0.1 || ^5.0 || ^6.0",
+    "orchestra/testbench-dusk": "3.8.2 || ^4.0.1 || ^5.0 || ^6.0 || ^7.0",
     "squizlabs/php_codesniffer": "^3.3",
     "timacdonald/log-fake": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "mockery/mockery": "^1.2",
     "orchestra/testbench-dusk": "3.8.2 || ^4.0.1 || ^5.0 || ^6.0 || ^7.0",
     "squizlabs/php_codesniffer": "^3.3",
-    "timacdonald/log-fake": "^1.0"
+    "timacdonald/log-fake": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
   "description": "Admin area tool utilities for Laravel",
   "license": "MIT",
   "require": {
-    "php": ">=7.3",
-    "laravel/framework": "5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-    "laravel/ui": "^1.0 || ^2.0 || ^3.0 || ^4.0"
+    "php": ">=8.0",
+    "laravel/framework": "^9.0",
+    "laravel/ui": "^4.0"
   },
   "require-dev": {
     "laravel/legacy-factories": "^1.0.4",
     "mockery/mockery": "^1.2",
-    "orchestra/testbench-dusk": "3.8.2 || ^4.0.1 || ^5.0 || ^6.0 || ^7.0",
+    "orchestra/testbench-dusk": "^7.0 || ^8.0",
     "squizlabs/php_codesniffer": "^3.3",
     "timacdonald/log-fake": "^2.0"
   },

--- a/tests/Browser/source/.gitignore
+++ b/tests/Browser/source/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Feature/AdminLinkTest.php
+++ b/tests/Feature/AdminLinkTest.php
@@ -63,7 +63,7 @@ class AdminLinkTest extends IntegrationTest
     {
         $link = AdminLink::create('Ciao', 'http://hej.com', 'Hejdå');
 
-        $this->assertRegExp('/aria-label="Ciao.*Hejdå"/', $link->toHtml());
+        $this->assertMatchesRegularExpression('/aria-label="Ciao.*Hejdå"/', $link->toHtml());
     }
 
     public function test_name_is_not_repeated_in_label()

--- a/tests/Feature/AdminVisitTest.php
+++ b/tests/Feature/AdminVisitTest.php
@@ -30,7 +30,6 @@ class AdminVisitTest extends IntegrationTest
         $visit = new ShowAdminVisit($link, $this->user);
 
         $serializedVisit = serialize($visit);
-        $visit->__wakeup(); // Restore any serialized models on the original object
         $unserializedVisit = unserialize($serializedVisit);
 
         $this->assertEquals($visit, $unserializedVisit, "Unserialization did not produce the original object structure");

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Log;
 use Kontenta\Kontour\Tests\Feature\Fakes\User;
 use Kontenta\Kontour\Tests\IntegrationTest;
 use TiMacDonald\Log\LogFake;
+use TiMacDonald\Log\LogEntry;
 use Illuminate\Support\Str;
 
 class AuthenticationTest extends IntegrationTest
@@ -75,11 +76,11 @@ class AuthenticationTest extends IntegrationTest
         $response = $this->actingAs($user, 'admin')->get($routeManager->indexUrl());
 
         $response->assertStatus(500);
-        Log::assertLogged('error', function ($message, $context) {
-            return (
-                Str::contains($message, 'Kontenta\Kontour\Contracts\AdminUser') and
-                Str::contains($message, 'Illuminate\Foundation\Auth\User') and
-                Str::contains($message, "'admin'")
+        Log::assertLogged(function (LogEntry $log) {
+            return ($log->level === 'error' and
+                Str::contains($log->message, 'Kontenta\Kontour\Contracts\AdminUser') and
+                Str::contains($log->message, 'Illuminate\Foundation\Auth\User') and
+                Str::contains($log->message, "'admin'")
             );
         });
     }

--- a/tests/Feature/AuthorizesWithAbilityTest.php
+++ b/tests/Feature/AuthorizesWithAbilityTest.php
@@ -63,7 +63,6 @@ class AuthorizesWithAbilityTest extends IntegrationTest
         $link->registerAbilityForAuthorization('testGate', $this->user);
 
         $serializedLink = serialize($link);
-        $link->__wakeup(); // Restore any serialized models on the original object
         $unserializedLink = unserialize($serializedLink);
 
         $this->assertTrue($unserializedLink->isAuthorized($this->user));

--- a/tests/Feature/ElementViewTests/TimeTest.php
+++ b/tests/Feature/ElementViewTests/TimeTest.php
@@ -15,7 +15,7 @@ class TimeTest extends IntegrationTest
         $output = View::make('kontour::elements.time', compact('carbon'))->render();
 
         $this->assertStringContainsString('datetime="' . $carbon->toAtomString() . '"', $output);
-        $this->assertRegExp('/>\d seconds? ago<\/time>$/', $output);
+        $this->assertMatchesRegularExpression('/>\d seconds? ago<\/time>$/', $output);
     }
 
     public function test_can_format_time()

--- a/tests/Feature/FormViewTests/CheckboxTest.php
+++ b/tests/Feature/FormViewTests/CheckboxTest.php
@@ -15,8 +15,8 @@ class CheckboxTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="test"\s*>/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="test"\s*>/', $output);
     }
 
     public function test_input_can_have_custom_control_id()
@@ -27,8 +27,8 @@ class CheckboxTest extends IntegrationTest
             'controlId' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="a"\s*>/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="a"\s*>/', $output);
     }
 
     public function test_input_can_have_id_prefix()
@@ -39,8 +39,8 @@ class CheckboxTest extends IntegrationTest
             'idPrefix' => 'pre-',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="pre-test"\s*>/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="pre-test"\s*>/', $output);
     }
 
     public function test_default_is_not_checked()
@@ -50,7 +50,7 @@ class CheckboxTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_can_be_checked()
@@ -61,7 +61,7 @@ class CheckboxTest extends IntegrationTest
             'checked' => true,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_default_value_is_1()
@@ -71,7 +71,7 @@ class CheckboxTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="1"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="1"[\S\s]*>/', $output);
     }
 
     public function test_default_value_can_be_set()
@@ -82,7 +82,7 @@ class CheckboxTest extends IntegrationTest
             'checkboxDefaultValue' => 2,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="2"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="2"[\S\s]*>/', $output);
     }
 
     public function test_value_can_be_set()
@@ -93,7 +93,7 @@ class CheckboxTest extends IntegrationTest
             'value' => 3,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="3"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="3"[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_not_used_if_no_errors()
@@ -105,7 +105,7 @@ class CheckboxTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_used_if_in_session_with_errors()
@@ -117,7 +117,7 @@ class CheckboxTest extends IntegrationTest
             'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_fallback_values_are_used_in_order()
@@ -144,9 +144,9 @@ class CheckboxTest extends IntegrationTest
             }
             $regexp = '/<input[\S\s]*checked[\S\s]*>/';
             if ($value) {
-                $this->assertRegExp($regexp, $output);
+                $this->assertMatchesRegularExpression($regexp, $output);
             } else {
-                $this->assertNotRegExp($regexp, $output);
+                $this->assertDoesNotMatchRegularExpression($regexp, $output);
             }
         }
     }
@@ -158,8 +158,8 @@ class CheckboxTest extends IntegrationTest
             'errors' => new MessageBag(['test' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_custom_errors_id_suffix()
@@ -170,8 +170,8 @@ class CheckboxTest extends IntegrationTest
             'errorsSuffix' => '-errors',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_autofocus()
@@ -182,6 +182,6 @@ class CheckboxTest extends IntegrationTest
             'autofocusControlId' => 'test',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*autofocus[\S\s]*>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/CheckboxesTest.php
+++ b/tests/Feature/FormViewTests/CheckboxesTest.php
@@ -16,7 +16,7 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*name="test\[]"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*name="test\[]"[\S\s]*>/', $output);
     }
 
     public function test_checkboxes_has_array_name_from_dot_notation()
@@ -27,7 +27,7 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*name="test\[name]\[in]\[dot]\[notation]\[]"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*name="test\[name]\[in]\[dot]\[notation]\[]"[\S\s]*>/', $output);
     }
 
     public function test_checkboxes_has_hidden_presence_input()
@@ -38,7 +38,7 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input type="hidden" name="test" value="">[\S\s]*<input[\S\s]*type="checkbox"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input type="hidden" name="test" value="">[\S\s]*<input[\S\s]*type="checkbox"[\S\s]*>/', $output);
     }
 
     public function test_checkboxes_has_hidden_presence_input_from_dot_notation()
@@ -49,7 +49,7 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input type="hidden" name="test\[name]\[in]\[dot]\[notation]" value="">[\S\s]*<input[\S\s]*type="checkbox"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input type="hidden" name="test\[name]\[in]\[dot]\[notation]" value="">[\S\s]*<input[\S\s]*type="checkbox"[\S\s]*>/', $output);
     }
 
     public function test_fieldset_can_have_custom_control_id()
@@ -61,7 +61,7 @@ class CheckboxesTest extends IntegrationTest
             'controlId' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<fieldset[\S\s]*id="a"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<fieldset[\S\s]*id="a"[\S\s]*>/', $output);
     }
 
     public function test_fieldset_can_have_id_prefix()
@@ -73,7 +73,7 @@ class CheckboxesTest extends IntegrationTest
             'idPrefix' => 'pre-',
         ])->render();
 
-        $this->assertRegExp('/<fieldset[\S\s]*id="pre-test"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<fieldset[\S\s]*id="pre-test"[\S\s]*>/', $output);
     }
 
     public function test_default_is_no_checkbox_selected()
@@ -84,7 +84,7 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_checkbox_can_be_selected()
@@ -96,7 +96,7 @@ class CheckboxesTest extends IntegrationTest
             'selected' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_multiple_checkboxes_can_be_selected()
@@ -108,8 +108,8 @@ class CheckboxesTest extends IntegrationTest
             'selected' => ['a', 'b'],
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
-        $this->assertRegExp('/<input[\S\s]*value="b"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="b"[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_groups()
@@ -121,7 +121,7 @@ class CheckboxesTest extends IntegrationTest
             'selected' => ['c', 'b'],
         ])->render();
 
-        $this->assertRegExp('/<fieldset[^>]*>[\S\s]*<input[^>]*value="a"[^>]*>A[\S\s]*<input[^>]*value="b"\s*checked[^>]*>B[\S\s]*<fieldset[^>]*>\s*<legend>A Group<\/legend>[\S\s]*<input[^>]*value="c"\s*checked[^>]*>C[\S\s]*<input[^>]*value="d"[^>]*>D[\S\s]*<\/fieldset>[\S\s]*<\/fieldset>/', $output);
+        $this->assertMatchesRegularExpression('/<fieldset[^>]*>[\S\s]*<input[^>]*value="a"[^>]*>A[\S\s]*<input[^>]*value="b"\s*checked[^>]*>B[\S\s]*<fieldset[^>]*>\s*<legend>A Group<\/legend>[\S\s]*<input[^>]*value="c"\s*checked[^>]*>C[\S\s]*<input[^>]*value="d"[^>]*>D[\S\s]*<\/fieldset>[\S\s]*<\/fieldset>/', $output);
     }
 
     public function test_old_value_is_not_used_if_no_errors()
@@ -134,7 +134,7 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_used_if_in_session_with_errors()
@@ -147,7 +147,7 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_fallback_values_are_used_in_order()
@@ -173,7 +173,7 @@ class CheckboxesTest extends IntegrationTest
             if (is_array($value)) {
                 $value = $value['test'];
             }
-            $this->assertRegExp('/<input[\S\s]*value="' . $value . '"[\S\s]*checked[\S\s]*>/', $output);
+            $this->assertMatchesRegularExpression('/<input[\S\s]*value="' . $value . '"[\S\s]*checked[\S\s]*>/', $output);
         }
     }
 
@@ -185,8 +185,8 @@ class CheckboxesTest extends IntegrationTest
             'errors' => new MessageBag(['test' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_error_option_referencing_error_element_with_errors()
@@ -200,11 +200,11 @@ class CheckboxesTest extends IntegrationTest
             ]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors\.1"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors\.1"[\S\s]*>[\S\s]*Error for option[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="testErrors\.1"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors\.1"[\S\s]*>[\S\s]*Error for option[\S\s]*<\/\1>/', $output);
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_custom_errors_id_suffix()
@@ -216,8 +216,8 @@ class CheckboxesTest extends IntegrationTest
             'errorsSuffix' => '-errors',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_autofocus_on_first_option()
@@ -229,8 +229,8 @@ class CheckboxesTest extends IntegrationTest
             'autofocusControlId' => 'test',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>/', $output);
-        $this->assertNotRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
     }
 
     public function test_autofocus_on_specific_option()
@@ -242,8 +242,8 @@ class CheckboxesTest extends IntegrationTest
             'autofocusControlId' => 'test.1',
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>[\S\s]*<input/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>[\S\s]*<input/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
     }
 
     public function test_checkboxes_can_be_disabled()
@@ -255,7 +255,7 @@ class CheckboxesTest extends IntegrationTest
             'disabledOptions' => ['b'],
         ])->render();
 
-        $this->assertNotRegExp('/<input[^>]*value="a"[^>]*disabled[^>]*>/', $output);
-        $this->assertRegExp('/<input[^>]*value="b"[^>]*disabled[^>]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[^>]*value="a"[^>]*disabled[^>]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[^>]*value="b"[^>]*disabled[^>]*>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/EmailTest.php
+++ b/tests/Feature/FormViewTests/EmailTest.php
@@ -20,7 +20,7 @@ class EmailTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*type="email"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*type="email"[\S\s]*>/', $output);
     }
 
     public function test_input_type_can_be_specified()
@@ -30,7 +30,7 @@ class EmailTest extends IntegrationTest
             'type' => 'text',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*type="text"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*type="text"[\S\s]*>/', $output);
     }
 
     public function test_input_name_defaults_to_email()
@@ -39,7 +39,7 @@ class EmailTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*name="email"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*name="email"[\S\s]*>/', $output);
     }
 
     public function test_input_name_can_be_specified()
@@ -49,7 +49,7 @@ class EmailTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*name="test"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*name="test"[\S\s]*>/', $output);
     }
 
     public function test_email_input_has_default_attributes()
@@ -76,11 +76,11 @@ class EmailTest extends IntegrationTest
             ]
         ])->render();
 
-        $this->assertRegExp('/\s+autocomplete="off"\W/', $output);
-        $this->assertRegExp('/\s+autocapitalize="on"\W/', $output);
-        $this->assertRegExp('/\s+autocorrect="on"\W/', $output);
-        $this->assertRegExp('/\s+required\W/', $output);
-        $this->assertRegExp('/\s+a="b"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+autocomplete="off"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+autocapitalize="on"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+autocorrect="on"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+required\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+a="b"\W/', $output);
 
         foreach (self::$defaultEmailAttributes as $attribute => $default) {
             $this->assertStringNotContainsString("$attribute=\"$default\"", $output);

--- a/tests/Feature/FormViewTests/ErrorsTest.php
+++ b/tests/Feature/FormViewTests/ErrorsTest.php
@@ -26,6 +26,6 @@ class ErrorsTest extends IntegrationTest
             'errorsId' => 'errors',
         ])->render();
 
-        $this->assertRegExp('/<(\S*)[\S\s]*id="errors"[\S\s]*>[\S\s]*Error 1[\S\s]*Error 2[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="errors"[\S\s]*>[\S\s]*Error 1[\S\s]*Error 2[\S\s]*<\/\1>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/InputAttributesTest.php
+++ b/tests/Feature/FormViewTests/InputAttributesTest.php
@@ -16,7 +16,7 @@ class InputAttributesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/name="testName"\W/', $output);
+        $this->assertMatchesRegularExpression('/name="testName"\W/', $output);
     }
 
     public function test_name_in_dot_notation()
@@ -27,7 +27,7 @@ class InputAttributesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/name="test\[name]\[in]\[dot]\[notation]"\W/', $output);
+        $this->assertMatchesRegularExpression('/name="test\[name]\[in]\[dot]\[notation]"\W/', $output);
     }
 
     public function test_has_control_id()
@@ -38,7 +38,7 @@ class InputAttributesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/\s+id="testId"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+id="testId"\W/', $output);
     }
 
     public function test_aria_invalid_not_present_on_error_free_input()
@@ -49,7 +49,7 @@ class InputAttributesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/aria-invalid/', $output);
+        $this->assertDoesNotMatchRegularExpression('/aria-invalid/', $output);
     }
 
     public function test_error_free_input_not_referencing_error_element()
@@ -60,7 +60,7 @@ class InputAttributesTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/aria-describedby/', $output);
+        $this->assertDoesNotMatchRegularExpression('/aria-describedby/', $output);
     }
 
     public function test_error_input_has_aria_invalid()
@@ -72,7 +72,7 @@ class InputAttributesTest extends IntegrationTest
             'errorsId' => 'errorsId',
         ])->render();
 
-        $this->assertRegExp('/\s+aria-invalid="true"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+aria-invalid="true"\W/', $output);
     }
 
     public function test_error_input_referencing_error_element()
@@ -84,7 +84,7 @@ class InputAttributesTest extends IntegrationTest
             'errorsId' => 'errorsId',
         ])->render();
 
-        $this->assertRegExp('/\s+aria-describedby="errorsId"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+aria-describedby="errorsId"\W/', $output);
     }
 
     public function test_aria_describedby_can_be_set()
@@ -96,7 +96,7 @@ class InputAttributesTest extends IntegrationTest
             'controlAttributes' => ['aria-describedby' => 'descriptionId'],
         ])->render();
 
-        $this->assertRegExp('/\s+aria-describedby="descriptionId"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+aria-describedby="descriptionId"\W/', $output);
     }
 
     public function test_error_input_prepending_aria_describedby()
@@ -109,7 +109,7 @@ class InputAttributesTest extends IntegrationTest
             'controlAttributes' => ['aria-describedby' => 'descriptionId'],
         ])->render();
 
-        $this->assertRegExp('/\s+aria-describedby="errorsId\sdescriptionId"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+aria-describedby="errorsId\sdescriptionId"\W/', $output);
     }
 
     public function test_control_attributes()
@@ -128,8 +128,8 @@ class InputAttributesTest extends IntegrationTest
             ],
         ])->render();
 
-        $this->assertRegExp('/\s+a="b"\s+boolean\s+true\s+b="false"\s+c="0"\W/', $output);
-        $this->assertNotRegExp('/\sfalse\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+a="b"\s+boolean\s+true\s+b="false"\s+c="0"\W/', $output);
+        $this->assertDoesNotMatchRegularExpression('/\sfalse\W/', $output);
     }
 
     public function test_can_have_autofocus()
@@ -141,7 +141,7 @@ class InputAttributesTest extends IntegrationTest
             'autofocusControlId' => 'testId',
         ])->render();
 
-        $this->assertRegExp('/\s+autofocus\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+autofocus\W/', $output);
     }
 
     public function test_other_element_can_have_autofocus()
@@ -153,7 +153,7 @@ class InputAttributesTest extends IntegrationTest
             'autofocusControlId' => 'otherId',
         ])->render();
 
-        $this->assertNotRegExp('/autofocus/', $output);
+        $this->assertDoesNotMatchRegularExpression('/autofocus/', $output);
     }
 
     public function test_can_have_placeholder()
@@ -165,6 +165,6 @@ class InputAttributesTest extends IntegrationTest
             'placeholder' => 'Placeholder text',
         ])->render();
 
-        $this->assertRegExp('/\s+placeholder="Placeholder text"\W/', $output);
+        $this->assertMatchesRegularExpression('/\s+placeholder="Placeholder text"\W/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/InputTest.php
+++ b/tests/Feature/FormViewTests/InputTest.php
@@ -15,7 +15,7 @@ class InputTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*type="text"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*type="text"[\S\s]*>/', $output);
     }
 
     public function test_input_type_can_be_specified()
@@ -26,7 +26,7 @@ class InputTest extends IntegrationTest
             'type' => 'email',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*type="email"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*type="email"[\S\s]*>/', $output);
     }
 
     public function test_input_is_referenced_by_label()
@@ -36,8 +36,8 @@ class InputTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="test"\s*>/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="test"\s*>/', $output);
     }
 
     public function test_input_can_have_custom_control_id()
@@ -48,8 +48,8 @@ class InputTest extends IntegrationTest
             'controlId' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="a"\s*>/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="a"\s*>/', $output);
     }
 
     public function test_input_can_have_id_prefix()
@@ -60,8 +60,8 @@ class InputTest extends IntegrationTest
             'idPrefix' => 'pre-',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="pre-test"\s*>/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="pre-test"\s*>/', $output);
     }
 
     public function test_value_attribute_is_not_present_on_password_inputs()
@@ -73,8 +73,8 @@ class InputTest extends IntegrationTest
             'value' => 'secret',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*type="password"[\S\s]*>/', $output);
-        $this->assertNotRegExp('/<input[\S\s]*value="[^"]*"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*type="password"[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*value="[^"]*"[\S\s]*>/', $output);
     }
 
     public function test_default_value_is_empty_string()
@@ -84,7 +84,7 @@ class InputTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value=""[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value=""[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_not_used_if_no_errors()
@@ -96,7 +96,7 @@ class InputTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*value="old"[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*value="old"[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_used_if_in_session_with_errors()
@@ -108,7 +108,7 @@ class InputTest extends IntegrationTest
             'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="old"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="old"[\S\s]*>/', $output);
     }
 
     public function test_fallback_values_are_used_in_order()
@@ -134,7 +134,7 @@ class InputTest extends IntegrationTest
             if (is_array($value)) {
                 $value = $value['test'];
             }
-            $this->assertRegExp('/<input[\S\s]*value="' . $value . '"[\S\s]*>/', $output);
+            $this->assertMatchesRegularExpression('/<input[\S\s]*value="' . $value . '"[\S\s]*>/', $output);
         }
     }
 
@@ -145,8 +145,8 @@ class InputTest extends IntegrationTest
             'errors' => new MessageBag(['test' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_dot_notation_error_input_referencing_error_element_with_errors()
@@ -156,8 +156,8 @@ class InputTest extends IntegrationTest
             'errors' => new MessageBag(['test.dot.notation' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="test.dot.notationErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test.dot.notationErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="test.dot.notationErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test.dot.notationErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_custom_errors_id_suffix()
@@ -168,8 +168,8 @@ class InputTest extends IntegrationTest
             'errorsSuffix' => '-errors',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_autofocus()
@@ -180,6 +180,6 @@ class InputTest extends IntegrationTest
             'autofocusControlId' => 'test',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*autofocus[\S\s]*>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/LabelTest.php
+++ b/tests/Feature/FormViewTests/LabelTest.php
@@ -13,28 +13,28 @@ class LabelTest extends IntegrationTest
     {
         $output = View::make('kontour::forms.label', ['name' => 'test'])->render();
 
-        $this->assertRegExp('/<label[\S\s]*>[\S\s]*<\/label>/', $output);
+        $this->assertMatchesRegularExpression('/<label[\S\s]*>[\S\s]*<\/label>/', $output);
     }
 
     public function test_custom_label_tag()
     {
         $output = View::make('kontour::forms.label', ['name' => 'test', 'labelTag' => 'legend'])->render();
 
-        $this->assertRegExp('/<legend[\S\s]*>[\S\s]*<\/legend>/', $output);
+        $this->assertMatchesRegularExpression('/<legend[\S\s]*>[\S\s]*<\/legend>/', $output);
     }
 
     public function test_label_references_control()
     {
         $output = View::make('kontour::forms.label', ['name' => 'test', 'controlId' => 'a'])->render();
 
-        $this->assertRegExp('/<label[\S\s]*for="a"[\S\s]*>[\S\s]*<\/label>/', $output);
+        $this->assertMatchesRegularExpression('/<label[\S\s]*for="a"[\S\s]*>[\S\s]*<\/label>/', $output);
     }
 
     public function test_generated_label_is_humanized()
     {
         $output = View::make('kontour::forms.label', ['name' => 'test_input.with.dot.notation[]'])->render();
 
-        $this->assertRegExp('/<label[\S\s]*>Test input with dot notation<\/label>/', $output);
+        $this->assertMatchesRegularExpression('/<label[\S\s]*>Test input with dot notation<\/label>/', $output);
     }
 
     public function test_validation_attribute_is_used_for_label()
@@ -42,20 +42,20 @@ class LabelTest extends IntegrationTest
         Lang::addLines(['validation.attributes.custom_input' => 'tEsT'], Lang::locale());
         $output = View::make('kontour::forms.label', ['name' => 'custom_input'])->render();
 
-        $this->assertRegExp('/<label[\S\s]*>TEsT<\/label>/', $output);
+        $this->assertMatchesRegularExpression('/<label[\S\s]*>TEsT<\/label>/', $output);
     }
 
     public function test_label_can_have_prepended_html()
     {
         $output = View::make('kontour::forms.label', ['name' => 'test', 'labelStart' => new HtmlString('<i>pre</i>')])->render();
 
-        $this->assertRegExp('/<label[\S\s]*><i>pre<\/i>[\S\s]*<\/label>/', $output);
+        $this->assertMatchesRegularExpression('/<label[\S\s]*><i>pre<\/i>[\S\s]*<\/label>/', $output);
     }
 
     public function test_label_can_have_appended_html()
     {
         $output = View::make('kontour::forms.label', ['name' => 'test', 'labelEnd' => new HtmlString('<i>post</i>')])->render();
 
-        $this->assertRegExp('/<label[\S\s]*>[\S\s]*<i>post<\/i><\/label>/', $output);
+        $this->assertMatchesRegularExpression('/<label[\S\s]*>[\S\s]*<i>post<\/i><\/label>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/MultiselectTest.php
+++ b/tests/Feature/FormViewTests/MultiselectTest.php
@@ -16,7 +16,7 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*name="test\[]"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*name="test\[]"[\S\s]*>/', $output);
     }
 
     public function test_multiselect_has_array_name_from_dot_notation()
@@ -27,7 +27,7 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*name="test\[name]\[in]\[dot]\[notation]\[]"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*name="test\[name]\[in]\[dot]\[notation]\[]"[\S\s]*>/', $output);
     }
 
 
@@ -39,7 +39,7 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input type="hidden" name="test" value="">[\S\s]*<select[\S\s]*multiple[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input type="hidden" name="test" value="">[\S\s]*<select[\S\s]*multiple[\S\s]*>/', $output);
     }
 
     public function test_multiselect_has_hidden_presence_input_from_dot_notation()
@@ -50,7 +50,7 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<input type="hidden" name="test\[name]\[in]\[dot]\[notation]" value="">[\S\s]*<select[\S\s]*multiple[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input type="hidden" name="test\[name]\[in]\[dot]\[notation]" value="">[\S\s]*<select[\S\s]*multiple[\S\s]*>/', $output);
     }
 
     public function test_select_is_referenced_by_label()
@@ -61,8 +61,8 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="test"\s*>/', $output);
-        $this->assertRegExp('/<select[\S\s]*id="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*id="test"\s*>/', $output);
     }
 
     public function test_select_can_have_custom_control_id()
@@ -74,8 +74,8 @@ class MultiselectTest extends IntegrationTest
             'controlId' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="a"\s*>/', $output);
-        $this->assertRegExp('/<select[\S\s]*id="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*id="a"\s*>/', $output);
     }
 
     public function test_select_can_have_id_prefix()
@@ -87,8 +87,8 @@ class MultiselectTest extends IntegrationTest
             'idPrefix' => 'pre-',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="pre-test"\s*>/', $output);
-        $this->assertRegExp('/<select[\S\s]*id="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*id="pre-test"\s*>/', $output);
     }
 
     public function test_default_is_no_option_selected()
@@ -99,7 +99,7 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<option[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_option_can_be_selected()
@@ -111,8 +111,8 @@ class MultiselectTest extends IntegrationTest
             'selected' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
-        $this->assertNotRegExp('/<option[\S\s]*value="b"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[\S\s]*value="b"[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_multiple_options_can_be_selected()
@@ -124,8 +124,8 @@ class MultiselectTest extends IntegrationTest
             'selected' => ['a', 'b'],
         ])->render();
 
-        $this->assertRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
-        $this->assertRegExp('/<option[\S\s]*value="b"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[\S\s]*value="b"[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_optgroups()
@@ -169,7 +169,7 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_used_if_in_session_with_errors()
@@ -182,7 +182,7 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
-        $this->assertRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_fallback_values_are_used_in_order()
@@ -209,7 +209,7 @@ class MultiselectTest extends IntegrationTest
             if (is_array($value)) {
                 $value = $value['test'];
             }
-            $this->assertRegExp('/<option[\S\s]*value="' . $value . '"[\S\s]*selected[\S\s]*>/', $output);
+            $this->assertMatchesRegularExpression('/<option[\S\s]*value="' . $value . '"[\S\s]*selected[\S\s]*>/', $output);
         }
     }
 
@@ -221,8 +221,8 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag(['test' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_custom_errors_id_suffix()
@@ -234,8 +234,8 @@ class MultiselectTest extends IntegrationTest
             'errorsSuffix' => '-errors',
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_error_on_option_referencing_error_element_with_errors()
@@ -246,8 +246,8 @@ class MultiselectTest extends IntegrationTest
             'errors' => new MessageBag(['test.1' => 'A message']),
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_autofocus()
@@ -259,7 +259,7 @@ class MultiselectTest extends IntegrationTest
             'autofocusControlId' => 'test',
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*autofocus[\S\s]*>/', $output);
     }
 
     public function test_options_can_be_disabled()
@@ -271,7 +271,7 @@ class MultiselectTest extends IntegrationTest
             'disabledOptions' => ['b'],
         ])->render();
 
-        $this->assertNotRegExp('/<option[^>]*value="a"[^>]*disabled[^>]*>/', $output);
-        $this->assertRegExp('/<option[^>]*value="b"[^>]*disabled[^>]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[^>]*value="a"[^>]*disabled[^>]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[^>]*value="b"[^>]*disabled[^>]*>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/RadiobuttonsTest.php
+++ b/tests/Feature/FormViewTests/RadiobuttonsTest.php
@@ -17,7 +17,7 @@ class RadiobuttonsTest extends IntegrationTest
             'controlId' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<fieldset[\S\s]*id="a"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<fieldset[\S\s]*id="a"[\S\s]*>/', $output);
     }
 
     public function test_fieldset_can_have_id_prefix()
@@ -29,7 +29,7 @@ class RadiobuttonsTest extends IntegrationTest
             'idPrefix' => 'pre-',
         ])->render();
 
-        $this->assertRegExp('/<fieldset[\S\s]*id="pre-test"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<fieldset[\S\s]*id="pre-test"[\S\s]*>/', $output);
     }
 
     public function test_default_is_no_radio_selected()
@@ -40,7 +40,7 @@ class RadiobuttonsTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_radio_can_be_selected()
@@ -52,7 +52,7 @@ class RadiobuttonsTest extends IntegrationTest
             'selected' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_groups()
@@ -64,7 +64,7 @@ class RadiobuttonsTest extends IntegrationTest
             'selected' => 'c',
         ])->render();
 
-        $this->assertRegExp('/<fieldset[^>]*>[\S\s]*<input[^>]*value="a"[^>]*>A[\S\s]*<input[^>]*value="b"[^>]*>B[\S\s]*<fieldset[^>]*>\s*<legend>A Group<\/legend>[\S\s]*<input[^>]*value="c"\s*checked[^>]*>C[\S\s]*<input[^>]*value="d"[^>]*>D[\S\s]*<\/fieldset>[\S\s]*<\/fieldset>/', $output);
+        $this->assertMatchesRegularExpression('/<fieldset[^>]*>[\S\s]*<input[^>]*value="a"[^>]*>A[\S\s]*<input[^>]*value="b"[^>]*>B[\S\s]*<fieldset[^>]*>\s*<legend>A Group<\/legend>[\S\s]*<input[^>]*value="c"\s*checked[^>]*>C[\S\s]*<input[^>]*value="d"[^>]*>D[\S\s]*<\/fieldset>[\S\s]*<\/fieldset>/', $output);
     }
 
     public function test_old_value_is_not_used_if_no_errors()
@@ -77,7 +77,7 @@ class RadiobuttonsTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_used_if_in_session_with_errors()
@@ -90,7 +90,7 @@ class RadiobuttonsTest extends IntegrationTest
             'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*value="a"[\S\s]*checked[\S\s]*>/', $output);
     }
 
     public function test_fallback_values_are_used_in_order()
@@ -116,7 +116,7 @@ class RadiobuttonsTest extends IntegrationTest
             if (is_array($value)) {
                 $value = $value['test'];
             }
-            $this->assertRegExp('/<input[\S\s]*value="' . $value . '"[\S\s]*checked[\S\s]*>/', $output);
+            $this->assertMatchesRegularExpression('/<input[\S\s]*value="' . $value . '"[\S\s]*checked[\S\s]*>/', $output);
         }
     }
 
@@ -128,8 +128,8 @@ class RadiobuttonsTest extends IntegrationTest
             'errors' => new MessageBag(['test' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_custom_errors_id_suffix()
@@ -141,8 +141,8 @@ class RadiobuttonsTest extends IntegrationTest
             'errorsSuffix' => '-errors',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_autofocus_on_first_option()
@@ -154,8 +154,8 @@ class RadiobuttonsTest extends IntegrationTest
             'autofocusControlId' => 'test',
         ])->render();
 
-        $this->assertRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>/', $output);
-        $this->assertNotRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
     }
 
     public function test_autofocus_on_specific_option()
@@ -167,8 +167,8 @@ class RadiobuttonsTest extends IntegrationTest
             'autofocusControlId' => 'test.1',
         ])->render();
 
-        $this->assertNotRegExp('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>[\S\s]*<input/', $output);
-        $this->assertRegExp('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[\S\s]*id="test\.0"[\S\s]*autofocus[\S\s]*>[\S\s]*<input/', $output);
+        $this->assertMatchesRegularExpression('/<input[\S\s]*id="test\.1"[\S\s]*autofocus[\S\s]*>/', $output);
     }
 
     public function test_radiobuttons_can_be_disabled()
@@ -180,7 +180,7 @@ class RadiobuttonsTest extends IntegrationTest
             'disabledOptions' => ['b'],
         ])->render();
 
-        $this->assertNotRegExp('/<input[^>]*value="a"[^>]*disabled[^>]*>/', $output);
-        $this->assertRegExp('/<input[^>]*value="b"[^>]*disabled[^>]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<input[^>]*value="a"[^>]*disabled[^>]*>/', $output);
+        $this->assertMatchesRegularExpression('/<input[^>]*value="b"[^>]*disabled[^>]*>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/SelectTest.php
+++ b/tests/Feature/FormViewTests/SelectTest.php
@@ -16,8 +16,8 @@ class SelectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="test"\s*>/', $output);
-        $this->assertRegExp('/<select[\S\s]*id="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*id="test"\s*>/', $output);
     }
 
     public function test_select_can_have_custom_control_id()
@@ -29,8 +29,8 @@ class SelectTest extends IntegrationTest
             'controlId' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="a"\s*>/', $output);
-        $this->assertRegExp('/<select[\S\s]*id="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*id="a"\s*>/', $output);
     }
 
     public function test_select_can_have_id_prefix()
@@ -42,8 +42,8 @@ class SelectTest extends IntegrationTest
             'idPrefix' => 'pre-',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="pre-test"\s*>/', $output);
-        $this->assertRegExp('/<select[\S\s]*id="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*id="pre-test"\s*>/', $output);
     }
 
     public function test_default_is_no_option_selected()
@@ -54,7 +54,7 @@ class SelectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<option[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_option_can_be_selected()
@@ -66,7 +66,7 @@ class SelectTest extends IntegrationTest
             'selected' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_optgroups()
@@ -106,7 +106,7 @@ class SelectTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_old_value_is_used_if_in_session_with_errors()
@@ -119,7 +119,7 @@ class SelectTest extends IntegrationTest
             'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
-        $this->assertRegExp('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[\S\s]*value="a"[\S\s]*selected[\S\s]*>/', $output);
     }
 
     public function test_fallback_values_are_used_in_order()
@@ -146,7 +146,7 @@ class SelectTest extends IntegrationTest
             if (is_array($value)) {
                 $value = $value['test'];
             }
-            $this->assertRegExp('/<option[\S\s]*value="' . $value . '"[\S\s]*selected[\S\s]*>/', $output);
+            $this->assertMatchesRegularExpression('/<option[\S\s]*value="' . $value . '"[\S\s]*selected[\S\s]*>/', $output);
         }
     }
 
@@ -158,8 +158,8 @@ class SelectTest extends IntegrationTest
             'errors' => new MessageBag(['test' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_custom_errors_id_suffix()
@@ -171,8 +171,8 @@ class SelectTest extends IntegrationTest
             'errorsSuffix' => '-errors',
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_autofocus()
@@ -184,7 +184,7 @@ class SelectTest extends IntegrationTest
             'autofocusControlId' => 'test',
         ])->render();
 
-        $this->assertRegExp('/<select[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<select[\S\s]*autofocus[\S\s]*>/', $output);
     }
 
     public function test_placeholder_becomes_first_option()
@@ -213,7 +213,7 @@ class SelectTest extends IntegrationTest
             'placeholder' => 'Select one',
         ])->render();
 
-        $this->assertNotRegExp('/<option[\S\s]*value=""[\S\s]*>Select one<\/option>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[\S\s]*value=""[\S\s]*>Select one<\/option>/', $output);
     }
 
     public function test_options_can_be_disabled()
@@ -225,7 +225,7 @@ class SelectTest extends IntegrationTest
             'disabledOptions' => ['b'],
         ])->render();
 
-        $this->assertNotRegExp('/<option[^>]*value="a"[^>]*disabled[^>]*>/', $output);
-        $this->assertRegExp('/<option[^>]*value="b"[^>]*disabled[^>]*>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<option[^>]*value="a"[^>]*disabled[^>]*>/', $output);
+        $this->assertMatchesRegularExpression('/<option[^>]*value="b"[^>]*disabled[^>]*>/', $output);
     }
 }

--- a/tests/Feature/FormViewTests/TextareaTest.php
+++ b/tests/Feature/FormViewTests/TextareaTest.php
@@ -15,8 +15,8 @@ class TextareaTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="test"\s*>/', $output);
-        $this->assertRegExp('/<textarea[\S\s]*id="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*id="test"\s*>/', $output);
     }
 
     public function test_textarea_can_have_custom_control_id()
@@ -27,8 +27,8 @@ class TextareaTest extends IntegrationTest
             'controlId' => 'a',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="a"\s*>/', $output);
-        $this->assertRegExp('/<textarea[\S\s]*id="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="a"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*id="a"\s*>/', $output);
     }
 
     public function test_textarea_can_have_id_prefix()
@@ -39,8 +39,8 @@ class TextareaTest extends IntegrationTest
             'idPrefix' => 'pre-',
         ])->render();
 
-        $this->assertRegExp('/<label\s*for="pre-test"\s*>/', $output);
-        $this->assertRegExp('/<textarea[\S\s]*id="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<label\s*for="pre-test"\s*>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*id="pre-test"\s*>/', $output);
     }
 
     public function test_default_value_is_empty_string()
@@ -50,7 +50,7 @@ class TextareaTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertRegExp('/<textarea[\S\s]*><\/textarea>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*><\/textarea>/', $output);
     }
 
     public function test_old_value_is_not_used_if_no_errors()
@@ -62,7 +62,7 @@ class TextareaTest extends IntegrationTest
             'errors' => new MessageBag,
         ])->render();
 
-        $this->assertNotRegExp('/<textarea[\S\s]*>old<\/textarea>/', $output);
+        $this->assertDoesNotMatchRegularExpression('/<textarea[\S\s]*>old<\/textarea>/', $output);
     }
 
     public function test_old_value_is_used_if_in_session_with_errors()
@@ -74,7 +74,7 @@ class TextareaTest extends IntegrationTest
             'errors' => new MessageBag(['another_field' => ['An error']]),
         ])->render();
 
-        $this->assertRegExp('/<textarea[\S\s]*>old<\/textarea>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*>old<\/textarea>/', $output);
     }
 
     public function test_fallback_values_are_used_in_order()
@@ -100,7 +100,7 @@ class TextareaTest extends IntegrationTest
             if (is_array($value)) {
                 $value = $value['test'];
             }
-            $this->assertRegExp('/<textarea[\S\s]*>' . $value . '<\/textarea>/', $output);
+            $this->assertMatchesRegularExpression('/<textarea[\S\s]*>' . $value . '<\/textarea>/', $output);
         }
     }
 
@@ -111,8 +111,8 @@ class TextareaTest extends IntegrationTest
             'errors' => new MessageBag(['test' => ['A message']]),
         ])->render();
 
-        $this->assertRegExp('/<textarea[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*aria-describedby="testErrors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="testErrors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_custom_errors_id_suffix()
@@ -123,8 +123,8 @@ class TextareaTest extends IntegrationTest
             'errorsSuffix' => '-errors',
         ])->render();
 
-        $this->assertRegExp('/<textarea[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
-        $this->assertRegExp('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*aria-describedby="test-errors"[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<(\S*)[\S\s]*id="test-errors"[\S\s]*>[\S\s]*A message[\S\s]*<\/\1>/', $output);
     }
 
     public function test_autofocus()
@@ -135,6 +135,6 @@ class TextareaTest extends IntegrationTest
             'autofocusControlId' => 'test',
         ])->render();
 
-        $this->assertRegExp('/<textarea[\S\s]*autofocus[\S\s]*>/', $output);
+        $this->assertMatchesRegularExpression('/<textarea[\S\s]*autofocus[\S\s]*>/', $output);
     }
 }

--- a/tests/IntegrationTestSetupTrait.php
+++ b/tests/IntegrationTestSetupTrait.php
@@ -30,6 +30,10 @@ trait IntegrationTestSetupTrait
     protected function getEnvironmentSetUp($app)
     {
         // Setup default database to use sqlite :memory:
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
         $app['config']->set('database.default', 'testing');
         $app['config']->set('auth.providers.users.model', User::class);
 


### PR DESCRIPTION
This PR adds support for Laravel 9 and drops support for Laravel 8 for the next release. See #198

- Removes the PHP version requirement from `composer.json` as it's already enforced by `laravel/framework`.
- Replaces deprecated PhpUnit regex assertions.
- Removes `__wakeup()` call (that was removed in PHP 8) from tests.

This PR includes setting up a new test-runner for PR:s with GitHub Actions. Closes #200